### PR TITLE
outlines is not always countable

### DIFF
--- a/src/Output.php
+++ b/src/Output.php
@@ -754,7 +754,7 @@ abstract class Output
      */
     protected function getOutBookmarks()
     {
-        $numbookmarks = (is_array($this->outlines) || is_countable($this->outlines))?count($this->outlines):0;
+        $numbookmarks = is_countable($this->outlines)?count($this->outlines):0;
         if ($numbookmarks <= 0) {
             return;
         }

--- a/src/Output.php
+++ b/src/Output.php
@@ -754,7 +754,7 @@ abstract class Output
      */
     protected function getOutBookmarks()
     {
-        $numbookmarks = count($this->outlines);
+        $numbookmarks = (is_array($this->outlines) || is_countable($this->outlines))?count($this->outlines):0;
         if ($numbookmarks <= 0) {
             return;
         }


### PR DESCRIPTION
In the example code, $this->outlines is not declared and throws a Exception: 

Uncaught TypeError: count(): Argument #1 ($value) must be of type Countable|array, null given in ..../vendor/tecnickcom/tc-lib-pdf/src/Output.php:757