### PR TITLE
Raising PHP version requirement to PHP 7.4

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -23,15 +23,11 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                php-version: ["7.2", "7.3", "7.4", "8.0", "8.1", "8.2"]
+                php-version: ["7.4", "8.0", "8.1", "8.2"]
                 experimental: [false]
                 os: [ubuntu-latest]
                 coverage-extension: [pcov]
                 include:
-                    #- { php-version: '5.3', experimental: false, os: ubuntu-latest, coverage-extension: 'xdebug' }
-                    #- { php-version: '5.4', experimental: false, os: ubuntu-latest, coverage-extension: 'xdebug' }
-                    #- { php-version: '5.5', experimental: false, os: ubuntu-latest, coverage-extension: 'xdebug' }
-                    - { php-version: '5.6', experimental: false, os: ubuntu-latest, coverage-extension: 'xdebug' }
                     - { php-version: '7.1', experimental: false, os: ubuntu-latest, coverage-extension: 'xdebug' }
         steps:
             - uses: actions/checkout@v4

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     }
   ],
   "require": {
-    "php": ">=5.6",
+    "php": ">=7.4",
     "ext-date": "*",
     "ext-pcre": "*",
     "tecnickcom/tc-lib-barcode": "^1.17",
@@ -35,11 +35,11 @@
   },
   "require-dev": {
     "pdepend/pdepend": "2.13.0",
-    "phploc/phploc": "7.0.2 || 6.0.2 || 5.0.0 || 4.0.1 || 3.0.1 || 2.1.5",
+    "phploc/phploc": "7.0.2",
     "phpmd/phpmd": "2.13.0",
-    "phpunit/phpunit": "10.1.2 || 9.6.7 || 8.5.31 || 7.5.20 || 6.5.14 || 5.7.27 || 4.8.36",
-    "sebastian/phpcpd": "6.0.3 || 5.0.2 || 4.1.0 || 3.0.1 || 2.0.4",
-    "squizlabs/php_codesniffer": "3.7.2 || 2.9.2"
+    "phpunit/phpunit": "10.1.2 || 9.6.7",
+    "sebastian/phpcpd": "6.0.3",
+    "squizlabs/php_codesniffer": "3.7.2",
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
# Description
PHP 7.4 has been EOL since end of last year, PHP 5.6 has been EOL for almost 5 years. Since this project still claims to not be release ready yet, I think it would be sane to raise the minimum requirement from 5.6 to at least 7.4. I would even advise to go a step further and raise it directly to 8.1, considering that 8.1 already is almost out of active support in a month. Yes, there are projects out there running on very old PHP versions which use this library, but those projects will not have had any maintenance and thus an update of their depdendencies anyway. If they ever do an update, TCPDF is the least of their problems.

...


## Checklist:

- [ ] The `make buildall` command has been run successfully without any error or warning.
- [ ] Any new code line is covered by unit tests and the coverage has not dropped.
- [ ] Any new code follows the style guidelines of this project.
- [ ] The code changes have been self-reviewed.
- [ ] Corresponding changes to the documentation have been made.
- [ ] The version has been updated in the VERSION file.

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue) → The patch number in the VERSION file has been increased.
- [ ] New feature (non-breaking change which adds functionality) → The minor number in the VERSION file has been increased.
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected) → The major number in the VERSION file has been increased.
- [ ] Automation.
- [ ] Documentation.
- [ ] Example.
- [ ] Testing.
