### PR TITLE
Adding static code analyzer phpstan

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,9 @@
     "phpmd/phpmd": "2.13.0",
     "phpunit/phpunit": "10.1.2 || 9.6.7 || 8.5.31 || 7.5.20 || 6.5.14 || 5.7.27 || 4.8.36",
     "sebastian/phpcpd": "6.0.3 || 5.0.2 || 4.1.0 || 3.0.1 || 2.0.4",
-    "squizlabs/php_codesniffer": "3.7.2 || 2.9.2"
+    "squizlabs/php_codesniffer": "3.7.2 || 2.9.2",
+    "phpstan/phpstan": "^1.10",
+    "phpstan/phpstan-deprecation-rules": "^1.1"
   },
   "autoload": {
     "psr-4": {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,10 @@
+includes:
+    - vendor/phpstan/phpstan-deprecation-rules/rules.neon
+parameters:
+  level: 5
+  paths:
+    - src
+  scanDirectories:
+    - vendor
+  ignoreErrors:
+  reportUnmatchedIgnoredErrors: false


### PR DESCRIPTION
# Description
The new structure of tc-lib-pdf is pretty good, however there is a lot of code which could be improved with the help of a static code analyzer. phpstan is such a tool and helps me greatly to improve my code quality. This adds a configuration for phpstan which I consider rather sane for a first run. To use this, just install it via composer and then run `vendor/bin/phpstan`. It will use the configuration found in the root and then scan the `/src` folder, using the content of the `/vendor` folder to add external symbols. 

Running this on this repo right now results in the following reported errors:
[phpstan.txt](https://github.com/tecnickcom/tc-lib-pdf/files/12781294/phpstan.txt)
...


## Checklist:

- [ ] The `make buildall` command has been run successfully without any error or warning.
- [ ] Any new code line is covered by unit tests and the coverage has not dropped.
- [ ] Any new code follows the style guidelines of this project.
- [ ] The code changes have been self-reviewed.
- [ ] Corresponding changes to the documentation have been made.
- [ ] The version has been updated in the VERSION file.

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue) → The patch number in the VERSION file has been increased.
- [ ] New feature (non-breaking change which adds functionality) → The minor number in the VERSION file has been increased.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) → The major number in the VERSION file has been increased.
- [X] Automation.
- [ ] Documentation.
- [ ] Example.
- [X] Testing.
