### PR TITLE
Converting codestyle to PSR-12 and adding .editorconfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,20 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style end of lines and a blank line at the end of the file
+[*]
+indent_style = tab
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.php]
+indent_style = space
+indent_size = 4
+
+[*.{js,json,scss,css,yml,vue}]
+indent_style = space
+indent_size = 2

--- a/Makefile
+++ b/Makefile
@@ -114,8 +114,8 @@ all: help
 
 # Full build and test sequence
 .PHONY: buildall
-buildall: deps 
-	cd vendor/tecnickcom/tc-lib-pdf-font/ && make buildall 
+buildall: deps
+	cd vendor/tecnickcom/tc-lib-pdf-font/ && make buildall
 	$(MAKE) codefix qa bz2 rpm deb
 
 # Package the library in a compressed bz2 archive
@@ -209,7 +209,7 @@ endif
 # Test source code for coding standard violations
 .PHONY: lint
 lint:
-	./vendor/bin/phpcs --ignore="./vendor/" --standard=psr2 src test
+	./vendor/bin/phpcs --ignore="./vendor/" --standard=psr12 src test
 	./vendor/bin/phpmd src text unusedcode,naming,design --exclude vendor
 	./vendor/bin/phpmd test text unusedcode,naming,design
 

--- a/src/ClassObjects.php
+++ b/src/ClassObjects.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * ClassObjects.php
  *
@@ -15,17 +16,17 @@
 
 namespace Com\Tecnick\Pdf;
 
-use \Com\Tecnick\Pdf\Exception as PdfException;
-use \Com\Tecnick\Color\Pdf as ObjColor;
-use \Com\Tecnick\Barcode\Barcode as ObjBarcode;
-use \Com\Tecnick\File\File as ObjFile;
-use \Com\Tecnick\File\Cache as ObjCache;
-use \Com\Tecnick\Unicode\Convert as ObjUniConvert;
-use \Com\Tecnick\Pdf\Encrypt\Encrypt as ObjEncrypt;
-use \Com\Tecnick\Pdf\Page\Page as ObjPage;
-use \Com\Tecnick\Pdf\Graph\Draw as ObjGraph;
-use \Com\Tecnick\Pdf\Font\Stack as ObjFont;
-use \Com\Tecnick\Pdf\Image\Import as ObjImage;
+use Com\Tecnick\Pdf\Exception as PdfException;
+use Com\Tecnick\Color\Pdf as ObjColor;
+use Com\Tecnick\Barcode\Barcode as ObjBarcode;
+use Com\Tecnick\File\File as ObjFile;
+use Com\Tecnick\File\Cache as ObjCache;
+use Com\Tecnick\Unicode\Convert as ObjUniConvert;
+use Com\Tecnick\Pdf\Encrypt\Encrypt as ObjEncrypt;
+use Com\Tecnick\Pdf\Page\Page as ObjPage;
+use Com\Tecnick\Pdf\Graph\Draw as ObjGraph;
+use Com\Tecnick\Pdf\Font\Stack as ObjFont;
+use Com\Tecnick\Pdf\Image\Import as ObjImage;
 
 /**
  * Com\Tecnick\Pdf\ClassObjects
@@ -117,16 +118,16 @@ abstract class ClassObjects extends \Com\Tecnick\Pdf\MetaInfo
      */
     protected function initClassObjects()
     {
-        $this->color = new ObjColor;
-        $this->barcode = new ObjBarcode;
-        $this->file = new ObjFile;
-        $this->cache = new ObjCache;
-        $this->uniconv = new ObjUniConvert;
-        
+        $this->color = new ObjColor();
+        $this->barcode = new ObjBarcode();
+        $this->file = new ObjFile();
+        $this->cache = new ObjCache();
+        $this->uniconv = new ObjUniConvert();
+
         if ($this->encrypt === null) {
             $this->encrypt = new ObjEncrypt();
         }
-        
+
         $this->page = new ObjPage(
             $this->unit,
             $this->color,
@@ -154,7 +155,7 @@ abstract class ClassObjects extends \Com\Tecnick\Pdf\MetaInfo
             $this->pdfa,
             $this->compress
         );
-        
+
         $this->image = new ObjImage(
             $this->kunit,
             $this->encrypt,

--- a/src/Exception.php
+++ b/src/Exception.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Exception.php
  *

--- a/src/MetaInfo.php
+++ b/src/MetaInfo.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * MetaInfo.php
  *
@@ -260,7 +261,7 @@ abstract class MetaInfo extends \Com\Tecnick\Pdf\Output
         if ($this->isunicode) {
             $str = $this->uniconv->toUTF16BE($str);
             if ($bom) {
-                $str = "\xFE\xFF".$str; // Byte Order Mark (BOM)
+                $str = "\xFE\xFF" . $str; // Byte Order Mark (BOM)
             }
         }
         return $this->encrypt->escapeDataString($str, $oid);
@@ -275,7 +276,7 @@ abstract class MetaInfo extends \Com\Tecnick\Pdf\Output
      */
     protected function getFormattedDate($time)
     {
-        return substr_replace(date('YmdHisO', intval($time)), '\'', (0 - 2), 0).'\'';
+        return substr_replace(date('YmdHisO', intval($time)), '\'', (0 - 2), 0) . '\'';
     }
 
     /**
@@ -298,10 +299,10 @@ abstract class MetaInfo extends \Com\Tecnick\Pdf\Output
     protected function getProducer()
     {
         return "\x54\x43\x50\x44\x46\x20"
-        .$this->version
-        ."\x20\x28\x68\x74\x74\x70\x73\x3a\x2f\x2f\x74\x63\x70\x64\x66\x2e\x6f\x72\x67\x29";
+        . $this->version
+        . "\x20\x28\x68\x74\x74\x70\x73\x3a\x2f\x2f\x74\x63\x70\x64\x66\x2e\x6f\x72\x67\x29";
     }
-    
+
     /**
      * Returns a formatted date for meta information
      *
@@ -315,7 +316,7 @@ abstract class MetaInfo extends \Com\Tecnick\Pdf\Output
         if (empty($time)) {
             $time = $this->doctime;
         }
-        return $this->encrypt->escapeDataString('D:'.$this->getFormattedDate($time), $oid);
+        return $this->encrypt->escapeDataString('D:' . $this->getFormattedDate($time), $oid);
     }
 
     /**
@@ -328,19 +329,19 @@ abstract class MetaInfo extends \Com\Tecnick\Pdf\Output
     {
         $oid = ++$this->pon;
         $this->objid['info'] = $oid;
-        $out = $oid.' 0 obj'."\n"
-        .'<<'
-        .' /Creator '.$this->getOutTextString($this->creator, $oid, true)
-        .' /Author '.$this->getOutTextString($this->author, $oid, true)
-        .' /Subject '.$this->getOutTextString($this->subject, $oid, true)
-        .' /Title '.$this->getOutTextString($this->title, $oid, true)
-        .' /Keywords '.$this->getOutTextString($this->keywords, $oid, true)
-        .' /Producer '.$this->getOutTextString($this->getProducer(), $oid, true)
-        .' /CreationDate '.$this->getOutDateTimeString($this->doctime, $oid)
-        .' /ModDate '.$this->getOutDateTimeString($this->docmodtime, $oid)
-        .' /Trapped /False'
-        .' >>'."\n"
-        .'endobj'."\n";
+        $out = $oid . ' 0 obj' . "\n"
+        . '<<'
+        . ' /Creator ' . $this->getOutTextString($this->creator, $oid, true)
+        . ' /Author ' . $this->getOutTextString($this->author, $oid, true)
+        . ' /Subject ' . $this->getOutTextString($this->subject, $oid, true)
+        . ' /Title ' . $this->getOutTextString($this->title, $oid, true)
+        . ' /Keywords ' . $this->getOutTextString($this->keywords, $oid, true)
+        . ' /Producer ' . $this->getOutTextString($this->getProducer(), $oid, true)
+        . ' /CreationDate ' . $this->getOutDateTimeString($this->doctime, $oid)
+        . ' /ModDate ' . $this->getOutDateTimeString($this->docmodtime, $oid)
+        . ' /Trapped /False'
+        . ' >>' . "\n"
+        . 'endobj' . "\n";
         return $out;
     }
 
@@ -391,12 +392,12 @@ abstract class MetaInfo extends \Com\Tecnick\Pdf\Output
      */
     protected function getOutXMP()
     {
-        $uuid = 'uuid:'.substr($this->fileid, 0, 8)
-        .'-'.substr($this->fileid, 8, 4)
-        .'-'.substr($this->fileid, 12, 4)
-        .'-'.substr($this->fileid, 16, 4)
-        .'-'.substr($this->fileid, 20, 12);
-        
+        $uuid = 'uuid:' . substr($this->fileid, 0, 8)
+        . '-' . substr($this->fileid, 8, 4)
+        . '-' . substr($this->fileid, 12, 4)
+        . '-' . substr($this->fileid, 16, 4)
+        . '-' . substr($this->fileid, 20, 12);
+
         // @codingStandardsIgnoreStart
         $xmp = '<?xpacket begin="'.$this->uniconv->chr(0xfeff).'" id="W5M0MpCehiHzreSzNTczkc9d"?>'."\n"
         .'<x:xmpmeta xmlns:x="adobe:ns:meta/" x:xmptk="Adobe XMP Core 4.2.1-c043 52.372728, 2009/01/18-15:08:04">'."\n"
@@ -509,15 +510,15 @@ abstract class MetaInfo extends \Com\Tecnick\Pdf\Output
 
         $oid = ++$this->pon;
         $this->objid['xmp'] = $oid;
-        $out = $oid.' 0 obj'."\n"
-        .'<<'
-        .' /Type /Metadata'
-        .' /Subtype /XML'
-        .' /Length '.strlen($xmp)
-        .' >> stream'."\n"
-        .$xmp."\n"
-        .'endstream'."\n"
-        .'endobj'."\n";
+        $out = $oid . ' 0 obj' . "\n"
+        . '<<'
+        . ' /Type /Metadata'
+        . ' /Subtype /XML'
+        . ' /Length ' . strlen($xmp)
+        . ' >> stream' . "\n"
+        . $xmp . "\n"
+        . 'endstream' . "\n"
+        . 'endobj' . "\n";
 
         return $out;
     }
@@ -561,7 +562,7 @@ abstract class MetaInfo extends \Com\Tecnick\Pdf\Output
                 $box = $this->page->$box[$val];
             }
         }
-        return ' /'.$name.' /'.$box;
+        return ' /' . $name . ' /' . $box;
     }
 
     /**
@@ -582,7 +583,7 @@ abstract class MetaInfo extends \Com\Tecnick\Pdf\Output
                 $mode = $valid[$name];
             }
         }
-        return ' /PrintScaling /'.$mode;
+        return ' /PrintScaling /' . $mode;
     }
 
     /**
@@ -604,7 +605,7 @@ abstract class MetaInfo extends \Com\Tecnick\Pdf\Output
                 $mode = $valid[$name];
             }
         }
-        return ' /Duplex /'.$mode;
+        return ' /Duplex /' . $mode;
     }
 
     /**
@@ -617,7 +618,7 @@ abstract class MetaInfo extends \Com\Tecnick\Pdf\Output
     protected function getBooleanMode($name)
     {
         if (isset($this->viewerpref[$name])) {
-            return ' /'.$name.' '.var_export((bool)$this->viewerpref[$name], true);
+            return ' /' . $name . ' ' . var_export((bool)$this->viewerpref[$name], true);
         }
         return '';
     }
@@ -643,7 +644,7 @@ abstract class MetaInfo extends \Com\Tecnick\Pdf\Output
         $out .= $this->getBooleanMode('CenterWindow');
         $out .= $this->getBooleanMode('DisplayDocTitle');
         if (isset($vpr['NonFullScreenPageMode'])) {
-            $out .= ' /NonFullScreenPageMode /'.$this->page->getDisplay($vpr['NonFullScreenPageMode']);
+            $out .= ' /NonFullScreenPageMode /' . $this->page->getDisplay($vpr['NonFullScreenPageMode']);
         }
         $out .= $this->getPageBoxName('ViewArea');
         $out .= $this->getPageBoxName('ViewClip');
@@ -655,12 +656,12 @@ abstract class MetaInfo extends \Com\Tecnick\Pdf\Output
         if (isset($vpr['PrintPageRange'])) {
             $PrintPageRangeNum = '';
             foreach ($vpr['PrintPageRange'] as $pnum) {
-                $PrintPageRangeNum .= ' '.($pnum - 1).'';
+                $PrintPageRangeNum .= ' ' . ($pnum - 1) . '';
             }
-            $out .= ' /PrintPageRange ['.$PrintPageRangeNum.' ]';
+            $out .= ' /PrintPageRange [' . $PrintPageRangeNum . ' ]';
         }
         if (isset($vpr['NumCopies'])) {
-            $out .= ' /NumCopies '.intval($vpr['NumCopies']);
+            $out .= ' /NumCopies ' . intval($vpr['NumCopies']);
         }
         $out .= ' >>';
         return $out;

--- a/src/Output.php
+++ b/src/Output.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Output.php
  *
@@ -15,7 +16,7 @@
 
 namespace Com\Tecnick\Pdf;
 
-use \Com\Tecnick\Pdf\Font\Output as OutFont;
+use Com\Tecnick\Pdf\Font\Output as OutFont;
 
 /**
  * Com\Tecnick\Pdf\Output
@@ -84,14 +85,14 @@ abstract class Output extends \Com\Tecnick\Pdf\Text
     public function getOutPDFString()
     {
         $out = $this->getOutPDFHeader()
-            .$this->getOutPDFBody();
+            . $this->getOutPDFBody();
         $startxref = strlen($out);
         $offset = $this->getPDFObjectOffsets($out);
         $out .= $this->getOutPDFXref($offset)
-            .$this->getOutPDFTrailer()
-            .'startxref'."\n"
-            .$startxref."\n"
-            .'%%EOF'."\n";
+            . $this->getOutPDFTrailer()
+            . 'startxref' . "\n"
+            . $startxref . "\n"
+            . '%%EOF' . "\n";
         $out .= $this->signDocument($out);
         return $out;
     }
@@ -103,8 +104,8 @@ abstract class Output extends \Com\Tecnick\Pdf\Text
      */
     protected function getOutPDFHeader()
     {
-        return '%PDF-'.$this->pdfver."\n"
-            ."%\xE2\xE3\xCF\xD3\n";
+        return '%PDF-' . $this->pdfver . "\n"
+            . "%\xE2\xE3\xCF\xD3\n";
     }
 
     /**
@@ -160,7 +161,7 @@ abstract class Output extends \Com\Tecnick\Pdf\Text
      */
     protected function getPDFObjectOffsets($data)
     {
-        preg_match_all('/(([0-9]+)[\s][0-9]+[\s]obj[\n])/i', $data, $matches, PREG_SET_ORDER|PREG_OFFSET_CAPTURE);
+        preg_match_all('/(([0-9]+)[\s][0-9]+[\s]obj[\n])/i', $data, $matches, PREG_SET_ORDER | PREG_OFFSET_CAPTURE);
         $offset = array();
         foreach ($matches as $item) {
             $offset[($item[2][0])] = $item[2][1];
@@ -178,17 +179,17 @@ abstract class Output extends \Com\Tecnick\Pdf\Text
      */
     protected function getOutPDFXref($offset)
     {
-        $out = 'xref'."\n"
-            .'0 '.($this->pon + 1)."\n"
-            .'0000000000 65535 f '."\n";
+        $out = 'xref' . "\n"
+            . '0 ' . ($this->pon + 1) . "\n"
+            . '0000000000 65535 f ' . "\n";
         $freegen = ($this->pon + 2);
         end($offset);
         $lastobj = key($offset);
         for ($idx = 1; $idx <= $lastobj; ++$idx) {
             if (isset($offset[$idx])) {
-                $out .= sprintf('%010d 00000 n '."\n", $offset[$idx]);
+                $out .= sprintf('%010d 00000 n ' . "\n", $offset[$idx]);
             } else {
-                $out .= sprintf('0000000000 %05d f '."\n", $freegen);
+                $out .= sprintf('0000000000 %05d f ' . "\n", $freegen);
                 ++$freegen;
             }
         }
@@ -204,17 +205,17 @@ abstract class Output extends \Com\Tecnick\Pdf\Text
      */
     protected function getOutPDFTrailer()
     {
-        $out = 'trailer'."\n"
-            .'<<'
-            .' /Size '.($this->pon + 1)
-            .' /Root '.$this->objid['catalog'].' 0 R'
-            .' /Info '.$this->objid['info'].' 0 R';
+        $out = 'trailer' . "\n"
+            . '<<'
+            . ' /Size ' . ($this->pon + 1)
+            . ' /Root ' . $this->objid['catalog'] . ' 0 R'
+            . ' /Info ' . $this->objid['info'] . ' 0 R';
         $enc = $this->encrypt->getEncryptionData();
         if (!empty($enc['objid'])) {
-            $out .= ' /Encrypt '.$enc['objid'].' 0 R';
+            $out .= ' /Encrypt ' . $enc['objid'] . ' 0 R';
         }
-        $out .= ' /ID [ <'.$this->fileid.'> <'.$this->fileid.'> ]'
-            .' >>'."\n";
+        $out .= ' /ID [ <' . $this->fileid . '> <' . $this->fileid . '> ]'
+            . ' >>' . "\n";
         return $out;
     }
 
@@ -228,21 +229,21 @@ abstract class Output extends \Com\Tecnick\Pdf\Text
         if (!$this->pdfa && !$this->sRGB) {
             return '';
         }
-        
+
         $oid = ++$this->pon;
         $this->objid['srgbicc'] = $oid;
-        $out = $oid.' 0 obj'."\n";
-        $icc = file_get_contents(dirname(__FILE__).'/include/sRGB.icc.z');
+        $out = $oid . ' 0 obj' . "\n";
+        $icc = file_get_contents(dirname(__FILE__) . '/include/sRGB.icc.z');
         $icc = $this->encrypt->encryptString($icc, $oid);
         $out .= '<<'
-            .' /N 3'
-            .' /Filter /FlateDecode'
-            .' /Length '.strlen($icc)
-            .' >>'
-            .' stream'."\n"
-            .$icc."\n"
-            .'endstream'."\n"
-            .'endobj'."\n";
+            . ' /N 3'
+            . ' /Filter /FlateDecode'
+            . ' /Length ' . strlen($icc)
+            . ' >>'
+            . ' stream' . "\n"
+            . $icc . "\n"
+            . 'endstream' . "\n"
+            . 'endobj' . "\n";
         return $out;
     }
 
@@ -258,14 +259,14 @@ abstract class Output extends \Com\Tecnick\Pdf\Text
         }
         $oid = $this->objid['catalog'];
         $out = ' /OutputIntents [<<'
-            .' /Type /OutputIntent'
-            .' /S /GTS_PDFA1'
-            .' /OutputCondition '.$this->getOutTextString('sRGB IEC61966-2.1', $oid, true)
-            .' /OutputConditionIdentifier '.$this->getOutTextString('sRGB IEC61966-2.1', $oid, true)
-            .' /RegistryName '.$this->getOutTextString('http://www.color.org', $oid, true)
-            .' /Info '.$this->getOutTextString('sRGB IEC61966-2.1', $oid, true)
-            .' /DestOutputProfile '.$this->objid['srgbicc'].' 0 R'
-            .' >>]';
+            . ' /Type /OutputIntent'
+            . ' /S /GTS_PDFA1'
+            . ' /OutputCondition ' . $this->getOutTextString('sRGB IEC61966-2.1', $oid, true)
+            . ' /OutputConditionIdentifier ' . $this->getOutTextString('sRGB IEC61966-2.1', $oid, true)
+            . ' /RegistryName ' . $this->getOutTextString('http://www.color.org', $oid, true)
+            . ' /Info ' . $this->getOutTextString('sRGB IEC61966-2.1', $oid, true)
+            . ' /DestOutputProfile ' . $this->objid['srgbicc'] . ' 0 R'
+            . ' >>]';
         return $out;
     }
 
@@ -278,12 +279,12 @@ abstract class Output extends \Com\Tecnick\Pdf\Text
     {
         $oid = $this->objid['catalog'];
         $out = ' /OutputIntents [<<'
-            .' /Type /OutputIntent'
-            .' /S /GTS_PDFX'
-            .' /OutputConditionIdentifier '.$this->getOutTextString('OFCOM_PO_P1_F60_95', $oid, true)
-            .' /RegistryName '.$this->getOutTextString('http://www.color.org', $oid, true)
-            .' /Info '.$this->getOutTextString('OFCOM_PO_P1_F60_95', $oid, true)
-            .' >>]';
+            . ' /Type /OutputIntent'
+            . ' /S /GTS_PDFX'
+            . ' /OutputConditionIdentifier ' . $this->getOutTextString('OFCOM_PO_P1_F60_95', $oid, true)
+            . ' /RegistryName ' . $this->getOutTextString('http://www.color.org', $oid, true)
+            . ' /Info ' . $this->getOutTextString('OFCOM_PO_P1_F60_95', $oid, true)
+            . ' >>]';
         return $out;
     }
 
@@ -318,7 +319,7 @@ abstract class Output extends \Com\Tecnick\Pdf\Text
         $lyrobjs_off = '';
         $lyrobjs_lock = '';
         foreach ($this->pdflayer as $layer) {
-            $layer_obj_ref = ' '.$layer['objid'].' 0 R';
+            $layer_obj_ref = ' ' . $layer['objid'] . ' 0 R';
             $lyrobjs .= $layer_obj_ref;
             if ($layer['view'] === false) {
                 $lyrobjs_off .= $layer_obj_ref;
@@ -327,24 +328,24 @@ abstract class Output extends \Com\Tecnick\Pdf\Text
                 $lyrobjs_lock .= $layer_obj_ref;
             }
         }
-        $out = ' /OCProperties << /OCGs ['.$lyrobjs.' ]'
-            .' /D <<'
-            .' /Name '.$this->getOutTextString('Layers', $oid, true)
-            .' /Creator '.$this->getOutTextString($this->creator, $oid, true)
-            .' /BaseState /ON'
-            .' /OFF ['.$lyrobjs_off.']'
-            .' /Locked ['.$lyrobjs_lock.']'
-            .' /Intent /View'
-            .' /AS ['
-            .' << /Event /Print /OCGs ['.$lyrobjs.'] /Category [/Print] >>'
-            .' << /Event /View /OCGs ['.$lyrobjs.'] /Category [/View] >>'
-            .' ]'
-            .' /Order ['.$lyrobjs.']'
-            .' /ListMode /AllPages'
+        $out = ' /OCProperties << /OCGs [' . $lyrobjs . ' ]'
+            . ' /D <<'
+            . ' /Name ' . $this->getOutTextString('Layers', $oid, true)
+            . ' /Creator ' . $this->getOutTextString($this->creator, $oid, true)
+            . ' /BaseState /ON'
+            . ' /OFF [' . $lyrobjs_off . ']'
+            . ' /Locked [' . $lyrobjs_lock . ']'
+            . ' /Intent /View'
+            . ' /AS ['
+            . ' << /Event /Print /OCGs [' . $lyrobjs . '] /Category [/Print] >>'
+            . ' << /Event /View /OCGs [' . $lyrobjs . '] /Category [/View] >>'
+            . ' ]'
+            . ' /Order [' . $lyrobjs . ']'
+            . ' /ListMode /AllPages'
             //.' /RBGroups ['..']'
             //.' /Locked ['..']'
-            .' >>'
-            .' >>';
+            . ' >>'
+            . ' >>';
         return $out;
     }
 
@@ -357,40 +358,40 @@ abstract class Output extends \Com\Tecnick\Pdf\Text
     {
         $oid = ++$this->pon;
         $this->objid['catalog'] = $oid;
-        $out = $oid.' 0 obj'."\n"
-            .'<<'
-            .' /Type /Catalog'
-            .' /Version /'.$this->pdfver
+        $out = $oid . ' 0 obj' . "\n"
+            . '<<'
+            . ' /Type /Catalog'
+            . ' /Version /' . $this->pdfver
             //.' /Extensions <<>>'
-            .' /Pages '.$this->objid['pages'].' 0 R'
+            . ' /Pages ' . $this->objid['pages'] . ' 0 R'
             //.' /PageLabels ' //...
-            .' /Names <<';
+            . ' /Names <<';
         if (!$this->pdfa && !empty($this->objid['javascript'])) {
-            $out .= ' /JavaScript '.$this->objid['javascript'];
+            $out .= ' /JavaScript ' . $this->objid['javascript'];
         }
         if (!empty($this->efnames)) {
             $out .= ' /EmbeddedFiles << /Names [';
             foreach ($this->efnames as $fn => $fref) {
-                $out .= ' '.$this->getOutTextString($fn, $oid).' '.$fref;
+                $out .= ' ' . $this->getOutTextString($fn, $oid) . ' ' . $fref;
             }
             $out .= ' ] >>';
         }
         $out .= ' >>';
 
         if (!empty($this->objid['dests'])) {
-            $out .= ' /Dests '.($this->objid['dests']).' 0 R';
+            $out .= ' /Dests ' . ($this->objid['dests']) . ' 0 R';
         }
 
         $out .= $this->getOutViewerPref();
 
         if (!empty($this->display['layout'])) {
-            $out .= ' /PageLayout /'.$this->display['layout'];
+            $out .= ' /PageLayout /' . $this->display['layout'];
         }
         if (!empty($this->display['mode'])) {
-            $out .= ' /PageMode /'.$this->display['mode'];
+            $out .= ' /PageMode /' . $this->display['mode'];
         }
         if (!empty($this->outlines)) {
-            $out .= ' /Outlines '.$this->OutlineRoot.' 0 R';
+            $out .= ' /Outlines ' . $this->OutlineRoot . ' 0 R';
             $out .= ' /PageMode /UseOutlines';
         }
 
@@ -399,23 +400,23 @@ abstract class Output extends \Com\Tecnick\Pdf\Text
         $firstpage = $this->page->getPage(0);
         $fpo = $firstpage['n'];
         if ($this->display['zoom'] == 'fullpage') {
-            $out .= ' /OpenAction ['.$fpo.' 0 R /Fit]';
+            $out .= ' /OpenAction [' . $fpo . ' 0 R /Fit]';
         } elseif ($this->display['zoom'] == 'fullwidth') {
-            $out .= ' /OpenAction ['.$fpo.' 0 R /FitH null]';
+            $out .= ' /OpenAction [' . $fpo . ' 0 R /FitH null]';
         } elseif ($this->display['zoom'] == 'real') {
-            $out .= ' /OpenAction ['.$fpo.' 0 R /XYZ null null 1]';
+            $out .= ' /OpenAction [' . $fpo . ' 0 R /XYZ null null 1]';
         } elseif (!is_string($this->display['zoom'])) {
-            $out .= sprintf(' /OpenAction ['.$fpo.' 0 R /XYZ null null %F]', ($this->display['zoom'] / 100));
+            $out .= sprintf(' /OpenAction [' . $fpo . ' 0 R /XYZ null null %F]', ($this->display['zoom'] / 100));
         }
 
         //$out .= ' /AA <<>>';
         //$out .= ' /URI <<>>';
-        $out .= ' /Metadata '.$this->objid['xmp'].' 0 R';
+        $out .= ' /Metadata ' . $this->objid['xmp'] . ' 0 R';
         //$out .= ' /StructTreeRoot <<>>';
         //$out .= ' /MarkInfo <<>>';
 
         if (!empty($this->l['a_meta_language'])) {
-            $out .= ' /Lang '.$this->getOutTextString($this->l['a_meta_language'], $oid, true);
+            $out .= ' /Lang ' . $this->getOutTextString($this->l['a_meta_language'], $oid, true);
         }
 
         //$out .= ' /SpiderInfo <<>>';
@@ -424,27 +425,29 @@ abstract class Output extends \Com\Tecnick\Pdf\Text
         $out .= $this->getPDFLayers();
 
         // AcroForm
-        if (!empty($this->objid['form'])
+        if (
+            !empty($this->objid['form'])
             || ($this->sign && isset($this->signature['cert_type']))
-            || !empty($this->signature['appearance']['empty'])) {
+            || !empty($this->signature['appearance']['empty'])
+        ) {
             $out .= ' /AcroForm <<';
             $objrefs = '';
             if ($this->sign && isset($this->signature['cert_type'])) {
                 // set reference for signature object
-                $objrefs .= $this->objid['signature'].' 0 R';
+                $objrefs .= $this->objid['signature'] . ' 0 R';
             }
             if (!empty($this->signature['appearance']['empty'])) {
                 foreach ($this->signature['appearance']['empty'] as $esa) {
                     // set reference for empty signature objects
-                    $objrefs .= ' '.$esa['objid'].' 0 R';
+                    $objrefs .= ' ' . $esa['objid'] . ' 0 R';
                 }
             }
             if (!empty($this->objid['form'])) {
                 foreach ($this->objid['form'] as $objid) {
-                    $objrefs .= ' '.$objid.' 0 R';
+                    $objrefs .= ' ' . $objid . ' 0 R';
                 }
             }
-            $out .= ' /Fields ['.$objrefs.']';
+            $out .= ' /Fields [' . $objrefs . ']';
             // It's better to turn off this value and set the appearance stream for
             // each annotation (/AP) to avoid conflicts with signature fields.
             if (empty($this->signature['approval']) || ($this->signature['approval'] != 'A')) {
@@ -462,28 +465,30 @@ abstract class Output extends \Com\Tecnick\Pdf\Text
             if (!empty($this->annotation_fonts)) {
                 $out .= ' /DR << /Font <<';
                 foreach ($this->annotation_fonts as $fontkey => $fontid) {
-                    $out .= ' /F'.$fontid.' '.$this->font->getFont($fontkey)['n'].' 0 R';
+                    $out .= ' /F' . $fontid . ' ' . $this->font->getFont($fontkey)['n'] . ' 0 R';
                 }
                 $out .= ' >> >>';
             }
 
             $font = $this->font->getFont('helvetica');
-            $out .= ' /DA (/F'.$font['i'].' 0 Tf 0 g)';
-            $out .= ' /Q '.(($this->rtl)?'2':'0');
+            $out .= ' /DA (/F' . $font['i'] . ' 0 Tf 0 g)';
+            $out .= ' /Q ' . (($this->rtl) ? '2' : '0');
             //$out .= ' /XFA ';
             $out .= ' >>';
 
 
             // signatures
-            if ($this->sign && isset($this->signature['cert_type'])
-                && (empty($this->signature['approval']) || ($this->signature['approval'] != 'A'))) {
+            if (
+                $this->sign && isset($this->signature['cert_type'])
+                && (empty($this->signature['approval']) || ($this->signature['approval'] != 'A'))
+            ) {
                 $out .= ' /Perms << ';
                 if ($this->signature['cert_type'] > 0) {
                     $out .= '/DocMDP ';
                 } else {
                     $out .= '/UR3 ';
                 }
-                $out .= ($this->objid['signature'] + 1).' 0 R >>';
+                $out .= ($this->objid['signature'] + 1) . ' 0 R >>';
             }
         }
 
@@ -492,8 +497,8 @@ abstract class Output extends \Com\Tecnick\Pdf\Text
         //$out .= ' /Collection <<>>';
         //$out .= ' /NeedsRendering true';
 
-        $out .= ' >>'."\n"
-            .'endobj'."\n";
+        $out .= ' >>' . "\n"
+            . 'endobj' . "\n";
         return $out;
     }
 
@@ -511,18 +516,18 @@ abstract class Output extends \Com\Tecnick\Pdf\Text
         foreach ($this->pdflayer as $key => $layer) {
             $oid = ++$this->pon;
             $this->pdflayer[$key]['objid'] = $oid;
-            $out .= $oid.' 0 obj'."\n";
+            $out .= $oid . ' 0 obj' . "\n";
             $out .= '<< '
-                .' /Type /OCG'
-                .' /Name '.$this->getOutTextString($layer['name'], $oid, true)
-                .' /Usage <<';
+                . ' /Type /OCG'
+                . ' /Name ' . $this->getOutTextString($layer['name'], $oid, true)
+                . ' /Usage <<';
             if (isset($layer['print']) && ($layer['print'] !== null)) {
-                $out .= ' /Print <</PrintState /'.$this->getOnOff($layer['print']).'>>';
+                $out .= ' /Print <</PrintState /' . $this->getOnOff($layer['print']) . '>>';
             }
-            $out .= ' /View <</ViewState /'.$this->getOnOff($layer['view']).'>>'
-                .' >>'
-                .' >>'."\n"
-                .'endobj'."\n";
+            $out .= ' /View <</ViewState /' . $this->getOnOff($layer['view']) . '>>'
+                . ' >>'
+                . ' >>' . "\n"
+                . 'endobj' . "\n";
         }
         return $out;
     }
@@ -540,27 +545,27 @@ abstract class Output extends \Com\Tecnick\Pdf\Text
     {
         $stream = trim($stream);
         $oid = ++$this->pon;
-        $out = $oid.' 0 obj'."\n";
-        $this->xobjects['AX'.$oid] = array('n' => $oid);
+        $out = $oid . ' 0 obj' . "\n";
+        $this->xobjects['AX' . $oid] = array('n' => $oid);
         $out .= '<<'
-            .' /Type /XObject'
-            .' /Subtype /Form'
-            .' /FormType 1';
+            . ' /Type /XObject'
+            . ' /Subtype /Form'
+            . ' /FormType 1';
         if ($this->compress) {
             $stream = gzcompress($stream);
             $out .= ' /Filter /FlateDecode';
         }
         $stream = $this->_getrawstream($stream);
         $rect = sprintf('%F %F', $width, $height);
-        $out .= ' /BBox [0 0 '.$rect.']'
-            .' /Matrix [1 0 0 1 0 0]'
-            .' /Resources 2 0 R'
-            .' /Length '.strlen($stream)
-            .' >>'
-            .' stream'."\n"
-            .$stream."\n"
-            .'endstream'."\n"
-            .'endobj'."\n";
+        $out .= ' /BBox [0 0 ' . $rect . ']'
+            . ' /Matrix [1 0 0 1 0 0]'
+            . ' /Resources 2 0 R'
+            . ' /Length ' . strlen($stream)
+            . ' >>'
+            . ' stream' . "\n"
+            . $stream . "\n"
+            . 'endstream' . "\n"
+            . 'endobj' . "\n";
         return $out;
     }
 
@@ -576,11 +581,11 @@ abstract class Output extends \Com\Tecnick\Pdf\Text
             if (empty($data['outdata'])) {
                 continue;
             }
-            $out .= ' '.$data['n'].' 0 R'."\n"
-                .'<<'
-                .' /Type /XObject'
-                .' /Subtype /Form'
-                .' /FormType 1';
+            $out .= ' ' . $data['n'] . ' 0 R' . "\n"
+                . '<<'
+                . ' /Type /XObject'
+                . ' /Subtype /Form'
+                . ' /FormType 1';
             $stream = trim($data['outdata']);
             if ($this->compress) {
                 $stream = gzcompress($stream);
@@ -594,13 +599,13 @@ abstract class Output extends \Com\Tecnick\Pdf\Text
                 (($data['h'] - $data['y']) * $this->kunit)
             );
             $out .= ' /Matrix [1 0 0 1 0 0]'
-                .' /Resources <<'
-                .' /ProcSet [/PDF /Text /ImageB /ImageC /ImageI]';
+                . ' /Resources <<'
+                . ' /ProcSet [/PDF /Text /ImageB /ImageC /ImageI]';
             if (!empty($data['fonts'])) {
                 $fonts = $data['fonts']->getFonts();
                 $out = ' /Font <<';
                 foreach ($fonts as $font) {
-                    $out .= ' /F'.$font['i'].' '.$font['n'].' 0 R';
+                    $out .= ' /F' . $font['i'] . ' ' . $font['n'] . ' 0 R';
                 }
                 $out .= ' >>';
             }
@@ -617,10 +622,10 @@ abstract class Output extends \Com\Tecnick\Pdf\Text
             if (!empty($data['images']) || !empty($data['xobjects'])) {
                 $out .= ' /XObject <<';
                 foreach ($data['images'] as $imgid) {
-                    $out .= ' /I'.$imgid.' '.$this->xobject['I'.$imgid]['n'].' 0 R';
+                    $out .= ' /I' . $imgid . ' ' . $this->xobject['I' . $imgid]['n'] . ' 0 R';
                 }
                 foreach ($data['xobjects'] as $sub_id => $sub_objid) {
-                    $out .= ' /'.$sub_id.' '.$sub_objid['n'].' 0 R';
+                    $out .= ' /' . $sub_id . ' ' . $sub_objid['n'] . ' 0 R';
                 }
                 $out .= ' >>';
             }
@@ -630,24 +635,24 @@ abstract class Output extends \Com\Tecnick\Pdf\Text
                 $out .= ' /Group << /Type /Group /S /Transparency';
                 if (is_array($data['group'])) {
                     if (!empty($data['group']['CS'])) {
-                        $out .= ' /CS /'.$data['group']['CS'];
+                        $out .= ' /CS /' . $data['group']['CS'];
                     }
                     if (isset($data['group']['I'])) {
-                        $out .= ' /I /'.($data['group']['I']===true?'true':'false');
+                        $out .= ' /I /' . ($data['group']['I'] === true ? 'true' : 'false');
                     }
                     if (isset($data['group']['K'])) {
-                        $out .= ' /K /'.($data['group']['K']===true?'true':'false');
+                        $out .= ' /K /' . ($data['group']['K'] === true ? 'true' : 'false');
                     }
                 }
                 $out .= ' >>';
             }
             $stream = $this->encrypt->encryptString($stream, $data['n']);
-            $out .= ' /Length '.strlen($stream)
-                .' >>'
-                .' stream'."\n"
-                .$stream."\n"
-                .'endstream'."\n"
-                .'endobj'."\n";
+            $out .= ' /Length ' . strlen($stream)
+                . ' >>'
+                . ' stream' . "\n"
+                . $stream . "\n"
+                . 'endstream' . "\n"
+                . 'endobj' . "\n";
         }
         return $out;
     }
@@ -660,17 +665,17 @@ abstract class Output extends \Com\Tecnick\Pdf\Text
     protected function getOutResourcesDict()
     {
         $this->objid['resdic'] = $this->page->getResourceDictObjID();
-        $out = $this->objid['resdic'].' 0 obj'."\n"
-            .'<<'
-            .' /ProcSet [/PDF /Text /ImageB /ImageC /ImageI]'
-            .$this->getOutFontDic()
-            .$this->getXObjectDic()
-            .$this->getLayerDic()
-            .$this->graph->getOutExtGStateResources()
-            .$this->graph->getOutGradientResources()
-            .$this->color->getPdfSpotResources()
-            .' >>'."\n"
-            .'endobj'."\n";
+        $out = $this->objid['resdic'] . ' 0 obj' . "\n"
+            . '<<'
+            . ' /ProcSet [/PDF /Text /ImageB /ImageC /ImageI]'
+            . $this->getOutFontDic()
+            . $this->getXObjectDic()
+            . $this->getLayerDic()
+            . $this->graph->getOutExtGStateResources()
+            . $this->graph->getOutGradientResources()
+            . $this->color->getPdfSpotResources()
+            . ' >>' . "\n"
+            . 'endobj' . "\n";
         return $out;
     }
 
@@ -686,17 +691,17 @@ abstract class Output extends \Com\Tecnick\Pdf\Text
         }
         $oid = ++$this->pon;
         $this->objid['dests'] = $oid;
-        $out .= $oid.' 0 obj'."\n"
-            .'<< ';
+        $out .= $oid . ' 0 obj' . "\n"
+            . '<< ';
         foreach ($this->dests as $name => $dst) {
             $page = $this->page->getPage($dst['p']);
             $poid = $page['n'];
             $pgx = ($dst['x'] * $this->page->getKUnit());
             $pgy = ($page['pheight'] - ($dst['y'] * $this->page->getKUnit()));
-            $out .= ' /'.$name.' '.sprintf('[%u 0 R /XYZ %F %F null]', $poid, $pgx, $pgy);
+            $out .= ' /' . $name . ' ' . sprintf('[%u 0 R /XYZ %F %F null]', $poid, $pgx, $pgy);
         }
-        $out .= ' >>'."\n"
-            .'endobj'."\n";
+        $out .= ' >>' . "\n"
+            . 'endobj' . "\n";
         return $out;
     }
 
@@ -724,16 +729,16 @@ abstract class Output extends \Com\Tecnick\Pdf\Text
             }
             // update name tree
             $oid = $data['f'];
-            $this->efnames[$name] = $oid.' 0 R';
+            $this->efnames[$name] = $oid . ' 0 R';
             // embedded file specification object
-            $out = $oid.' 0 obj'."\n"
-                .'<<'
-                .' /Type /Filespec /F '.$this->getOutTextString($name, $oid)
-                .' /UF '.$this->getOutTextString($name, $oid)
-                .' /AFRelationship /Source'
-                .' /EF <</F '.$data['n'].' 0 R>>'
-                .' >>'."\n"
-                .'endobj'."\n";
+            $out = $oid . ' 0 obj' . "\n"
+                . '<<'
+                . ' /Type /Filespec /F ' . $this->getOutTextString($name, $oid)
+                . ' /UF ' . $this->getOutTextString($name, $oid)
+                . ' /AFRelationship /Source'
+                . ' /EF <</F ' . $data['n'] . ' 0 R>>'
+                . ' >>' . "\n"
+                . 'endobj' . "\n";
             // embedded file object
             $filter = '';
             if ($this->pdfa == 3) {
@@ -744,17 +749,17 @@ abstract class Output extends \Com\Tecnick\Pdf\Text
             }
             $stream = $this->encrypt->encryptString($content, $data['n']);
             $out .= "\n"
-                .$data['n'].' 0 obj'."\n"
-                .'<<'
-                .' /Type /EmbeddedFile'
-                .$filter
-                .' /Length '.strlen($stream)
-                .' /Params <</Size '.$rawsize.'>>'
-                .' >>'
-                .' stream'."\n"
-                .$stream."\n"
-                .'endstream'."\n"
-                .'endobj'."\n";
+                . $data['n'] . ' 0 obj' . "\n"
+                . '<<'
+                . ' /Type /EmbeddedFile'
+                . $filter
+                . ' /Length ' . strlen($stream)
+                . ' /Params <</Size ' . $rawsize . '>>'
+                . ' >>'
+                . ' stream' . "\n"
+                . $stream . "\n"
+                . 'endstream' . "\n"
+                . 'endobj' . "\n";
             return $out;
         }
     }
@@ -822,35 +827,35 @@ abstract class Output extends \Com\Tecnick\Pdf\Text
                 $ory = $page['height'] - (($annot['y'] + $annot['h']) * $this->kunit);
                 $width = $annot['w'] * $this->kunit;
                 $height = $annot['h'] * $this->kunit;
-                $rect = sprintf('%F %F %F %F', $orx, $ory, $orx+$width, $ory+$height);
-                $out .= $oid.' 0 R'."\n"
-                    .'<<'
-                    .' /Type /Annot'
-                    .' /Subtype /'.$annot['opt']['subtype']
-                    .' /Rect ['.$rect.']';
+                $rect = sprintf('%F %F %F %F', $orx, $ory, $orx + $width, $ory + $height);
+                $out .= $oid . ' 0 R' . "\n"
+                    . '<<'
+                    . ' /Type /Annot'
+                    . ' /Subtype /' . $annot['opt']['subtype']
+                    . ' /Rect [' . $rect . ']';
                 $ft = array('Btn', 'Tx', 'Ch', 'Sig');
                 $formfield = (!empty($annot['opt']['ft']) && in_array($annot['opt']['ft'], $ft));
                 if ($formfield) {
-                    $out .= ' /FT /'.$annot['opt']['ft'];
+                    $out .= ' /FT /' . $annot['opt']['ft'];
                 }
                 if ($annot['opt']['subtype'] !== 'Link') {
-                    $out .= ' /Contents '.$this->getOutTextString($annot['txt'], $oid, true);
+                    $out .= ' /Contents ' . $this->getOutTextString($annot['txt'], $oid, true);
                 }
-                $out .= ' /P '.$page['n'].' 0 R'
-                    .' /NM '.$this->encrypt->escapeDataString(sprintf('%04u-%04u', $n, $key), $oid)
-                    .' /M '.$this->getOutDateTimeString($this->docmodtime, $oid)
-                    .$this->getOutAnnotationFlags($annot)
-                    .$this->getAnnotationAppearanceStream($annot, $width, $height)
-                    .$this->getAnnotationBorder($annot);
+                $out .= ' /P ' . $page['n'] . ' 0 R'
+                    . ' /NM ' . $this->encrypt->escapeDataString(sprintf('%04u-%04u', $n, $key), $oid)
+                    . ' /M ' . $this->getOutDateTimeString($this->docmodtime, $oid)
+                    . $this->getOutAnnotationFlags($annot)
+                    . $this->getAnnotationAppearanceStream($annot, $width, $height)
+                    . $this->getAnnotationBorder($annot);
                 if (!empty($annot['opt']['c']) && is_array($annot['opt']['c'])) {
-                    $out .= ' /C '.$this->getColorStringFromArray($annot['opt']['c']);
+                    $out .= ' /C ' . $this->getColorStringFromArray($annot['opt']['c']);
                 }
                 //$out .= ' /StructParent ';
                 //$out .= ' /OC ';
                 $out .= $this->getOutAnnotationMarkups($annot, $oid)
-                    .$this->getOutAnnotationOptSubtype($annot, $pagenum, $oid, $key)
-                    .' >>'."\n"
-                    .'endobj'."\n";
+                    . $this->getOutAnnotationOptSubtype($annot, $pagenum, $oid, $key)
+                    . ' >>' . "\n"
+                    . 'endobj' . "\n";
                 if ($formfield && !isset($this->radiobuttonGroups[$n][$annot['txt']])) {
                     $this->objid['form'][] = $oid;
                 }
@@ -869,31 +874,33 @@ abstract class Output extends \Com\Tecnick\Pdf\Text
     protected function getAnnotationRadiobuttonGroups($annot)
     {
         $out = '';
-        if (empty($this->radiobuttonGroups[$n][$annot['txt']])
-            || !is_array($this->radiobuttonGroups[$n][$annot['txt']])) {
+        if (
+            empty($this->radiobuttonGroups[$n][$annot['txt']])
+            || !is_array($this->radiobuttonGroups[$n][$annot['txt']])
+        ) {
             return $out;
         }
         $oid = $this->radiobuttonGroups[$n][$annot['txt']]['n'];
-        $out = $oid.' 0 obj'."\n"
-            .'<<'
-            .' /Type /Annot'
-            .' /Subtype /Widget'
-            .' /Rect [0 0 0 0]';
+        $out = $oid . ' 0 obj' . "\n"
+            . '<<'
+            . ' /Type /Annot'
+            . ' /Subtype /Widget'
+            . ' /Rect [0 0 0 0]';
         if ($this->radiobuttonGroups[$n][$annot['txt']]['#readonly#']) {
             // read only
             $out .= ' /F 68 /Ff 49153';
         } else {
             $out .= ' /F 4 /Ff 49152'; // default print for PDF/A
         }
-        $out .= ' /T '.$this->encrypt->escapeDataString($annot['txt'], $oid);
+        $out .= ' /T ' . $this->encrypt->escapeDataString($annot['txt'], $oid);
         if (!empty($annot['opt']['tu']) && is_string($annot['opt']['tu'])) {
-            $out .= ' /TU '.$this->encrypt->escapeDataString($annot['opt']['tu'], $oid);
+            $out .= ' /TU ' . $this->encrypt->escapeDataString($annot['opt']['tu'], $oid);
         }
         $out .= ' /FT /Btn /Kids [';
         $defval = '';
         foreach ($this->radiobuttonGroups[$n][$annot['txt']] as $key => $data) {
             if (isset($data['kid'])) {
-                $out .= ' '.$data['kid'].' 0 R';
+                $out .= ' ' . $data['kid'] . ' 0 R';
                 if ($data['def'] !== 'Off') {
                     $defval = $data['def'];
                 }
@@ -901,10 +908,10 @@ abstract class Output extends \Com\Tecnick\Pdf\Text
         }
         $out .= ' ]';
         if (!empty($defval)) {
-            $out .= ' /V /'.$defval;
+            $out .= ' /V /' . $defval;
         }
-        $out .= ' >>'."\n"
-            .'endobj'."\n";
+        $out .= ' >>' . "\n"
+            . 'endobj' . "\n";
         $this->objid['form'][] = $oid;
         // store object id to be used on Parent entry of Kids
         $this->radiobuttonGroups[$n][$annot['txt']] = $oid;
@@ -924,7 +931,7 @@ abstract class Output extends \Com\Tecnick\Pdf\Text
     {
         $out = '';
         if (!empty($annot['opt']['as']) && is_string($annot['opt']['as'])) {
-            $out .= ' /AS /'.$annot['opt']['as'];
+            $out .= ' /AS /' . $annot['opt']['as'];
         }
         if (empty($annot['opt']['ap'])) {
             return $out;
@@ -935,19 +942,19 @@ abstract class Output extends \Com\Tecnick\Pdf\Text
         } else {
             foreach ($annot['opt']['ap'] as $mode => $def) {
                 // $mode can be: n = normal; r = rollover; d = down;
-                $out .= ' /'.strtoupper($mode);
+                $out .= ' /' . strtoupper($mode);
                 if (is_array($def)) {
                     $out .= ' <<';
                     foreach ($def as $apstate => $stream) {
                         // reference to XObject that define the appearance for this mode-state
                         $apsobjid = $this->getOutAPXObjects($width, $height, $stream);
-                        $out .= ' /'.$apstate.' '.$apsobjid.' 0 R';
+                        $out .= ' /' . $apstate . ' ' . $apsobjid . ' 0 R';
                     }
                     $out .= ' >>';
                 } else {
                     // reference to XObject that define the appearance for this mode
                     $apsobjid = $this->getOutAPXObjects($width, $height, $def);
-                    $out .= ' '.$apsobjid.' 0 R';
+                    $out .= ' ' . $apsobjid . ' 0 R';
                 }
             }
         }
@@ -967,18 +974,18 @@ abstract class Output extends \Com\Tecnick\Pdf\Text
         $out = '';
         if (!empty($annot['opt']['bs']) && (is_array($annot['opt']['bs']))) {
             $out .= ' /BS <<'
-                .' /Type /Border';
+                . ' /Type /Border';
             if (isset($annot['opt']['bs']['w'])) {
-                $out .= ' /W '.intval($annot['opt']['bs']['w']);
+                $out .= ' /W ' . intval($annot['opt']['bs']['w']);
             }
             $bstyles = array('S', 'D', 'B', 'I', 'U');
             if (!empty($annot['opt']['bs']['s']) && in_array($annot['opt']['bs']['s'], $bstyles)) {
-                $out .= ' /S /'.$annot['opt']['bs']['s'];
+                $out .= ' /S /' . $annot['opt']['bs']['s'];
             }
             if (isset($annot['opt']['bs']['d']) && (is_array($annot['opt']['bs']['d']))) {
                 $out .= ' /D [';
                 foreach ($annot['opt']['bs']['d'] as $cord) {
-                    $out .= ' '.intval($cord);
+                    $out .= ' ' . intval($cord);
                 }
                 $out .= ']';
             }
@@ -987,12 +994,12 @@ abstract class Output extends \Com\Tecnick\Pdf\Text
             $out .= ' /Border [';
             if (isset($annot['opt']['border']) && (count($annot['opt']['border']) >= 3)) {
                 $out .= intval($annot['opt']['border'][0])
-                    .' '.intval($annot['opt']['border'][1])
-                    .' '.intval($annot['opt']['border'][2]);
+                    . ' ' . intval($annot['opt']['border'][1])
+                    . ' ' . intval($annot['opt']['border'][2]);
                 if (isset($annot['opt']['border'][3]) && is_array($annot['opt']['border'][3])) {
                     $out .= ' [';
                     foreach ($annot['opt']['border'][3] as $dash) {
-                        $out .= ' '.intval($dash);
+                        $out .= ' ' . intval($dash);
                     }
                     $out .= ' ]';
                 }
@@ -1005,14 +1012,16 @@ abstract class Output extends \Com\Tecnick\Pdf\Text
             $out .= ' /BE <<';
             $bstyles = array('S', 'C');
             if (!empty($annot['opt']['be']['s']) && in_array($annot['opt']['be']['s'], $bstyles)) {
-                $out .= ' /S /'.$annot['opt']['bs']['s'];
+                $out .= ' /S /' . $annot['opt']['bs']['s'];
             } else {
                 $out .= ' /S /S';
             }
-            if (isset($annot['opt']['be']['i'])
+            if (
+                isset($annot['opt']['be']['i'])
                 && ($annot['opt']['be']['i'] >= 0)
-                && ($annot['opt']['be']['i'] <= 2)) {
-                $out .= ' /I '.sprintf(' %F', $annot['opt']['be']['i']);
+                && ($annot['opt']['be']['i'] <= 2)
+            ) {
+                $out .= ' /I ' . sprintf(' %F', $annot['opt']['be']['i']);
             }
             $out .= '>>';
         }
@@ -1052,19 +1061,19 @@ abstract class Output extends \Com\Tecnick\Pdf\Text
             return $out;
         }
         if (!empty($annot['opt']['t']) && is_string($annot['opt']['t'])) {
-            $out .= ' /T '.$this->getOutTextString($annot['opt']['t'], $oid, true);
+            $out .= ' /T ' . $this->getOutTextString($annot['opt']['t'], $oid, true);
         }
         //$out .= ' /Popup ';
         if (isset($annot['opt']['ca'])) {
-            $out .= ' /CA '.sprintf('%F', floatval($annot['opt']['ca']));
+            $out .= ' /CA ' . sprintf('%F', floatval($annot['opt']['ca']));
         }
         if (isset($annot['opt']['rc'])) {
-            $out .= ' /RC '.$this->getOutTextString($annot['opt']['rc'], $oid, true);
+            $out .= ' /RC ' . $this->getOutTextString($annot['opt']['rc'], $oid, true);
         }
-        $out .= ' /CreationDate '.$this->getOutDateTimeString($this->doctime, $oid);
+        $out .= ' /CreationDate ' . $this->getOutDateTimeString($this->doctime, $oid);
         //$out .= ' /IRT ';
         if (isset($annot['opt']['subj'])) {
-            $out .= ' /Subj '.$this->getOutTextString($annot['opt']['subj'], $oid, true);
+            $out .= ' /Subj ' . $this->getOutTextString($annot['opt']['subj'], $oid, true);
         }
         //$out .= ' /RT ';
         //$out .= ' /IT ';
@@ -1089,7 +1098,7 @@ abstract class Output extends \Com\Tecnick\Pdf\Text
             // force print flag for PDF/A mode
             $fval |= 4;
         }
-        return' /F '.intval($fval);
+        return' /F ' . intval($fval);
     }
 
     /**
@@ -1223,11 +1232,11 @@ abstract class Output extends \Com\Tecnick\Pdf\Text
     {
         $out = '';
         if (isset($annot['opt']['open'])) {
-            $out .= ' /Open '. (strtolower($annot['opt']['open']) == 'true' ? 'true' : 'false');
+            $out .= ' /Open ' . (strtolower($annot['opt']['open']) == 'true' ? 'true' : 'false');
         }
         $iconsapp = array('Comment', 'Help', 'Insert', 'Key', 'NewParagraph', 'Note', 'Paragraph');
         if (isset($annot['opt']['name']) && in_array($annot['opt']['name'], $iconsapp)) {
-            $out .= ' /Name /'.$annot['opt']['name'];
+            $out .= ' /Name /' . $annot['opt']['name'];
         } else {
             $out .= ' /Name /Note';
         }
@@ -1238,10 +1247,10 @@ abstract class Output extends \Com\Tecnick\Pdf\Text
             return $out;
         }
         if ($hasStateModel && in_array($annot['opt']['statemodel'], $statemodels)) {
-            $out .= ' /StateModel /'.$annot['opt']['statemodel'];
+            $out .= ' /StateModel /' . $annot['opt']['statemodel'];
         } else {
             $annot['opt']['statemodel'] = 'Marked';
-            $out .= ' /StateModel /'.$annot['opt']['statemodel'];
+            $out .= ' /StateModel /' . $annot['opt']['statemodel'];
         }
         if ($annot['opt']['statemodel'] == 'Marked') {
             $states = array('Accepted', 'Unmarked');
@@ -1249,7 +1258,7 @@ abstract class Output extends \Com\Tecnick\Pdf\Text
             $states = array('Accepted', 'Rejected', 'Cancelled', 'Completed', 'None');
         }
         if ($hasState && in_array($annot['opt']['state'], $states)) {
-            $out .= ' /State /'.$annot['opt']['state'];
+            $out .= ' /State /' . $annot['opt']['state'];
         } else {
             if ($annot['opt']['statemodel'] == 'Marked') {
                 $out .= ' /State /Unmarked';
@@ -1275,53 +1284,55 @@ abstract class Output extends \Com\Tecnick\Pdf\Text
         if (!empty($annot['txt']) && is_string($annot['txt'])) {
             switch ($annot['txt'][0]) {
                 case '#': // internal destination
-                    $out .= ' /A << /S /GoTo /D /'.$this->encrypt->encodeNameObject(substr($annot['txt'], 1)).'>>';
+                    $out .= ' /A << /S /GoTo /D /' . $this->encrypt->encodeNameObject(substr($annot['txt'], 1)) . '>>';
                     break;
                 case '%': // embedded PDF file
                     $filename = basename(substr($annot['txt'], 1));
                     $out .= ' /A <<'
-                        .' /S /GoToE'
-                        .' /D [0 /Fit]'
-                        .' /NewWindow true'
-                        .' /T <<'
-                        .' /R /C /P '.($pagenum - 1)
-                        .' /A '.$this->embeddedfiles[$filename]['a']
-                        .' >>'
-                        .' >>';
+                        . ' /S /GoToE'
+                        . ' /D [0 /Fit]'
+                        . ' /NewWindow true'
+                        . ' /T <<'
+                        . ' /R /C /P ' . ($pagenum - 1)
+                        . ' /A ' . $this->embeddedfiles[$filename]['a']
+                        . ' >>'
+                        . ' >>';
                     break;
                 case '*': // embedded generic file
                     $filename = basename(substr($annot['txt'], 1));
                     $jsa = 'var D=event.target.doc;'
-                        .'var MyData=D.dataObjects;'
-                        .'for (var i in MyData)'
-                        .' if (MyData[i].path=="'.$filename.'")'
-                        .' D.exportDataObject( { cName : MyData[i].name, nLaunch : 2});';
-                    $out .= ' /A << /S /JavaScript /JS '.$this->getOutTextString($jsa, $oid, true).' >>';
+                        . 'var MyData=D.dataObjects;'
+                        . 'for (var i in MyData)'
+                        . ' if (MyData[i].path=="' . $filename . '")'
+                        . ' D.exportDataObject( { cName : MyData[i].name, nLaunch : 2});';
+                    $out .= ' /A << /S /JavaScript /JS ' . $this->getOutTextString($jsa, $oid, true) . ' >>';
                     break;
                 default:
                     $parsedUrl = parse_url($annot['txt']);
-                    if (empty($parsedUrl['scheme'])
+                    if (
+                        empty($parsedUrl['scheme'])
                         && (!empty($parsedUrl['path'])
-                        && strtolower(substr($parsedUrl['path'], -4)) == '.pdf')) {
+                        && strtolower(substr($parsedUrl['path'], -4)) == '.pdf')
+                    ) {
                         // relative link to a PDF file
                         $dest = '[0 /Fit]'; // default page 0
                         if (!empty($parsedUrl['fragment'])) {
                             // check for named destination
                             $tmp = explode('=', $parsedUrl['fragment']);
-                            $dest = '('.((count($tmp) == 2) ? $tmp[1] : $tmp[0]).')';
+                            $dest = '(' . ((count($tmp) == 2) ? $tmp[1] : $tmp[0]) . ')';
                         }
                         $out .= ' /A <<'
-                            .' /S /GoToR'
-                            .' /D '.$dest
-                            .' /F '.$this->encrypt->escapeDataString($this->unhtmlentities($parsedUrl['path']), $oid)
-                            .' /NewWindow true'
-                            .' >>';
+                            . ' /S /GoToR'
+                            . ' /D ' . $dest
+                            . ' /F ' . $this->encrypt->escapeDataString($this->unhtmlentities($parsedUrl['path']), $oid)
+                            . ' /NewWindow true'
+                            . ' >>';
                     } else {
                         // external URI link
                         $out .= ' /A <<'
-                            .' /S /URI'
-                            .' /URI '.$this->encrypt->escapeDataString($this->unhtmlentities($annot['txt']), $oid)
-                            .' >>';
+                            . ' /S /URI'
+                            . ' /URI ' . $this->encrypt->escapeDataString($this->unhtmlentities($annot['txt']), $oid)
+                            . ' >>';
                     }
                     break;
             }
@@ -1334,7 +1345,7 @@ abstract class Output extends \Com\Tecnick\Pdf\Text
         }
         $hmodes = array('N', 'I', 'O', 'P');
         if (!empty($annot['opt']['h']) && in_array($annot['opt']['h'], $hmodes)) {
-            $out .= ' /H /'.$annot['opt']['h'];
+            $out .= ' /H /' . $annot['opt']['h'];
         } else {
             $out .= ' /H /I';
         }
@@ -1354,16 +1365,16 @@ abstract class Output extends \Com\Tecnick\Pdf\Text
     {
         $out = '';
         if (!empty($annot['opt']['da'])) {
-            $out .= ' /DA ('.$annot['opt']['da'].')';
+            $out .= ' /DA (' . $annot['opt']['da'] . ')';
         }
         if (isset($annot['opt']['q']) && ($annot['opt']['q'] >= 0) && ($annot['opt']['q'] <= 2)) {
-            $out .= ' /Q '.intval($annot['opt']['q']);
+            $out .= ' /Q ' . intval($annot['opt']['q']);
         }
         if (isset($annot['opt']['rc'])) {
-            $out .= ' /RC '.$this->getOutTextString($annot['opt']['rc'], $annot_obj_id, true);
+            $out .= ' /RC ' . $this->getOutTextString($annot['opt']['rc'], $annot_obj_id, true);
         }
         if (isset($annot['opt']['ds'])) {
-            $out .= ' /DS '.$this->getOutTextString($annot['opt']['ds'], $annot_obj_id, true);
+            $out .= ' /DS ' . $this->getOutTextString($annot['opt']['ds'], $annot_obj_id, true);
         }
         if (isset($annot['opt']['cl']) && is_array($annot['opt']['cl'])) {
             $out .= ' /CL [';
@@ -1374,14 +1385,14 @@ abstract class Output extends \Com\Tecnick\Pdf\Text
         }
         $tfit = array('FreeText', 'FreeTextCallout', 'FreeTextTypeWriter');
         if (isset($annot['opt']['it']) && in_array($annot['opt']['it'], $tfit)) {
-            $out .= ' /IT /'.$annot['opt']['it'];
+            $out .= ' /IT /' . $annot['opt']['it'];
         }
         if (isset($annot['opt']['rd']) && is_array($annot['opt']['rd'])) {
             $l = $annot['opt']['rd'][0] * $this->kunit;
             $r = $annot['opt']['rd'][1] * $this->kunit;
             $t = $annot['opt']['rd'][2] * $this->kunit;
             $b = $annot['opt']['rd'][3] * $this->kunit;
-            $out .= ' /RD ['.sprintf('%F %F %F %F', $l, $r, $t, $b).']';
+            $out .= ' /RD [' . sprintf('%F %F %F %F', $l, $r, $t, $b) . ']';
         }
         $lineendings = array(
             'Square',
@@ -1396,7 +1407,7 @@ abstract class Output extends \Com\Tecnick\Pdf\Text
             'Slash'
         );
         if (isset($annot['opt']['le']) && in_array($annot['opt']['le'], $lineendings)) {
-            $out .= ' /LE /'.$annot['opt']['le'];
+            $out .= ' /LE /' . $annot['opt']['le'];
         }
         return $out;
     }
@@ -1587,10 +1598,10 @@ abstract class Output extends \Com\Tecnick\Pdf\Text
         }
         $filename = basename($annot['opt']['fs']);
         if (isset($this->embeddedfiles[$filename]['f'])) {
-            $out .= ' /FS '.$this->embeddedfiles[$filename]['f'].' 0 R';
+            $out .= ' /FS ' . $this->embeddedfiles[$filename]['f'] . ' 0 R';
             $iconsapp = array('Graph', 'Paperclip', 'PushPin', 'Tag');
             if (isset($annot['opt']['name']) && in_array($annot['opt']['name'], $iconsapp)) {
-                $out .= ' /Name /'.$annot['opt']['name'];
+                $out .= ' /Name /' . $annot['opt']['name'];
             } else {
                 $out .= ' /Name /PushPin';
             }
@@ -1617,10 +1628,10 @@ abstract class Output extends \Com\Tecnick\Pdf\Text
         if (isset($this->embeddedfiles[$filename]['f'])) {
             // ... TO BE COMPLETED ...
             // /R /C /B /E /CO /CP
-            $out .= ' /Sound '.$this->embeddedfiles[$filename]['f'].' 0 R';
+            $out .= ' /Sound ' . $this->embeddedfiles[$filename]['f'] . ' 0 R';
             $iconsapp = array('Speaker', 'Mic');
             if (isset($annot['opt']['name']) && in_array($annot['opt']['name'], $iconsapp)) {
-                $out .= ' /Name /'.$annot['opt']['name'];
+                $out .= ' /Name /' . $annot['opt']['name'];
             } else {
                 $out .= ' /Name /Speaker';
             }
@@ -1654,59 +1665,61 @@ abstract class Output extends \Com\Tecnick\Pdf\Text
         $out = '';
         $hmode = array('N', 'I', 'O', 'P', 'T');
         if (!empty($annot['opt']['h']) && in_array($annot['opt']['h'], $hmode)) {
-            $out .= ' /H /'.$annot['opt']['h'];
+            $out .= ' /H /' . $annot['opt']['h'];
         }
         if (!empty($annot['opt']['mk']) && is_array($annot['opt']['mk'])) {
             $out .= ' /MK <<';
             if (isset($annot['opt']['mk']['r'])) {
-                $out .= ' /R '.$annot['opt']['mk']['r'];
+                $out .= ' /R ' . $annot['opt']['mk']['r'];
             }
             if (isset($annot['opt']['mk']['bc']) && (is_array($annot['opt']['mk']['bc']))) {
-                $out .= ' /BC '.$this->getColorStringFromArray($annot['opt']['mk']['bc']);
+                $out .= ' /BC ' . $this->getColorStringFromArray($annot['opt']['mk']['bc']);
             }
             if (isset($annot['opt']['mk']['bg']) && (is_array($annot['opt']['mk']['bg']))) {
-                $out .= ' /BG '.$this->getColorStringFromArray($annot['opt']['mk']['bg']);
+                $out .= ' /BG ' . $this->getColorStringFromArray($annot['opt']['mk']['bg']);
             }
             if (isset($annot['opt']['mk']['ca'])) {
-                $out .= ' /CA '.$annot['opt']['mk']['ca'];
+                $out .= ' /CA ' . $annot['opt']['mk']['ca'];
             }
             if (isset($annot['opt']['mk']['rc'])) {
-                $out .= ' /RC '.$annot['opt']['mk']['rc'];
+                $out .= ' /RC ' . $annot['opt']['mk']['rc'];
             }
             if (isset($annot['opt']['mk']['ac'])) {
-                $out .= ' /AC '.$annot['opt']['mk']['ac'];
+                $out .= ' /AC ' . $annot['opt']['mk']['ac'];
             }
             if (isset($annot['opt']['mk']['i'])) {
                 $info = $this->getImageBuffer($annot['opt']['mk']['i']);
                 if ($info !== false) {
-                    $out .= ' /I '.$info['n'].' 0 R';
+                    $out .= ' /I ' . $info['n'] . ' 0 R';
                 }
             }
             if (isset($annot['opt']['mk']['ri'])) {
                 $info = $this->getImageBuffer($annot['opt']['mk']['ri']);
                 if ($info !== false) {
-                    $out .= ' /RI '.$info['n'].' 0 R';
+                    $out .= ' /RI ' . $info['n'] . ' 0 R';
                 }
             }
             if (isset($annot['opt']['mk']['ix'])) {
                 $info = $this->getImageBuffer($annot['opt']['mk']['ix']);
                 if ($info !== false) {
-                    $out .= ' /IX '.$info['n'].' 0 R';
+                    $out .= ' /IX ' . $info['n'] . ' 0 R';
                 }
             }
             if (!empty($annot['opt']['mk']['if']) && is_array($annot['opt']['mk']['if'])) {
                 $out .= ' /IF <<';
                 $if_sw = array('A', 'B', 'S', 'N');
                 if (isset($annot['opt']['mk']['if']['sw']) && in_array($annot['opt']['mk']['if']['sw'], $if_sw)) {
-                    $out .= ' /SW /'.$annot['opt']['mk']['if']['sw'];
+                    $out .= ' /SW /' . $annot['opt']['mk']['if']['sw'];
                 }
                 $if_s = array('A', 'P');
                 if (isset($annot['opt']['mk']['if']['s']) && in_array($annot['opt']['mk']['if']['s'], $if_s)) {
-                    $out .= ' /S /'.$annot['opt']['mk']['if']['s'];
+                    $out .= ' /S /' . $annot['opt']['mk']['if']['s'];
                 }
-                if (isset($annot['opt']['mk']['if']['a'])
+                if (
+                    isset($annot['opt']['mk']['if']['a'])
                     && (is_array($annot['opt']['mk']['if']['a']))
-                    && !empty($annot['opt']['mk']['if']['a'])) {
+                    && !empty($annot['opt']['mk']['if']['a'])
+                ) {
                     $out .= sprintf(
                         ' /A [%F %F]',
                         $annot['opt']['mk']['if']['a'][0],
@@ -1718,26 +1731,28 @@ abstract class Output extends \Com\Tecnick\Pdf\Text
                 }
                 $out .= '>>';
             }
-            if (isset($annot['opt']['mk']['tp'])
+            if (
+                isset($annot['opt']['mk']['tp'])
                 && ($annot['opt']['mk']['tp'] >= 0)
-                && ($annot['opt']['mk']['tp'] <= 6)) {
-                $out .= ' /TP '.intval($annot['opt']['mk']['tp']);
+                && ($annot['opt']['mk']['tp'] <= 6)
+            ) {
+                $out .= ' /TP ' . intval($annot['opt']['mk']['tp']);
             }
             $out .= '>>';
         }
         // --- Entries for field dictionaries ---
         if (isset($this->radiobuttonGroups[$n][$annot['txt']])) {
             // set parent
-            $out .= ' /Parent '.$this->radiobuttonGroups[$n][$annot['txt']].' 0 R';
+            $out .= ' /Parent ' . $this->radiobuttonGroups[$n][$annot['txt']] . ' 0 R';
         }
         if (isset($annot['opt']['t']) && is_string($annot['opt']['t'])) {
-            $out .= ' /T '.$this->encrypt->escapeDataString($annot['opt']['t'], $oid);
+            $out .= ' /T ' . $this->encrypt->escapeDataString($annot['opt']['t'], $oid);
         }
         if (isset($annot['opt']['tu']) && is_string($annot['opt']['tu'])) {
-            $out .= ' /TU '.$this->encrypt->escapeDataString($annot['opt']['tu'], $oid);
+            $out .= ' /TU ' . $this->encrypt->escapeDataString($annot['opt']['tu'], $oid);
         }
         if (isset($annot['opt']['tm']) && is_string($annot['opt']['tm'])) {
-            $out .= ' /TM '.$this->encrypt->escapeDataString($annot['opt']['tm'], $oid);
+            $out .= ' /TM ' . $this->encrypt->escapeDataString($annot['opt']['tm'], $oid);
         }
         if (isset($annot['opt']['ff'])) {
             if (is_array($annot['opt']['ff'])) {
@@ -1749,10 +1764,10 @@ abstract class Output extends \Com\Tecnick\Pdf\Text
             } else {
                 $flag = intval($annot['opt']['ff']);
             }
-            $out .= ' /Ff '.$flag;
+            $out .= ' /Ff ' . $flag;
         }
         if (isset($annot['opt']['maxlen'])) {
-            $out .= ' /MaxLen '.intval($annot['opt']['maxlen']);
+            $out .= ' /MaxLen ' . intval($annot['opt']['maxlen']);
         }
         if (isset($annot['opt']['v'])) {
             $out .= ' /V';
@@ -1761,10 +1776,10 @@ abstract class Output extends \Com\Tecnick\Pdf\Text
                     if (is_float($optval)) {
                         $optval = sprintf('%F', $optval);
                     }
-                    $out .= ' '.$optval;
+                    $out .= ' ' . $optval;
                 }
             } else {
-                $out .= ' '.$this->getOutTextString($annot['opt']['v'], $oid, true);
+                $out .= ' ' . $this->getOutTextString($annot['opt']['v'], $oid, true);
             }
         }
         if (isset($annot['opt']['dv'])) {
@@ -1774,10 +1789,10 @@ abstract class Output extends \Com\Tecnick\Pdf\Text
                     if (is_float($optval)) {
                         $optval = sprintf('%F', $optval);
                     }
-                    $out .= ' '.$optval;
+                    $out .= ' ' . $optval;
                 }
             } else {
-                $out .= ' '.$this->getOutTextString($annot['opt']['dv'], $oid, true);
+                $out .= ' ' . $this->getOutTextString($annot['opt']['dv'], $oid, true);
             }
         }
         if (isset($annot['opt']['rv'])) {
@@ -1787,43 +1802,43 @@ abstract class Output extends \Com\Tecnick\Pdf\Text
                     if (is_float($optval)) {
                         $optval = sprintf('%F', $optval);
                     }
-                    $out .= ' '.$optval;
+                    $out .= ' ' . $optval;
                 }
             } else {
-                $out .= ' '.$this->getOutTextString($annot['opt']['rv'], $oid, true);
+                $out .= ' ' . $this->getOutTextString($annot['opt']['rv'], $oid, true);
             }
         }
         if (!empty($annot['opt']['a'])) {
-            $out .= ' /A << '.$annot['opt']['a'].' >>';
+            $out .= ' /A << ' . $annot['opt']['a'] . ' >>';
         }
         if (!empty($annot['opt']['aa'])) {
-            $out .= ' /AA << '.$annot['opt']['aa'].' >>';
+            $out .= ' /AA << ' . $annot['opt']['aa'] . ' >>';
         }
         if (!empty($annot['opt']['da'])) {
-            $out .= ' /DA ('.$annot['opt']['da'].')';
+            $out .= ' /DA (' . $annot['opt']['da'] . ')';
         }
         if (isset($annot['opt']['q']) && ($annot['opt']['q'] >= 0) && ($annot['opt']['q'] <= 2)) {
-            $out .= ' /Q '.intval($annot['opt']['q']);
+            $out .= ' /Q ' . intval($annot['opt']['q']);
         }
         if (!empty($annot['opt']['opt']) && is_array($annot['opt']['opt'])) {
             $out .= ' /Opt [';
             foreach ($annot['opt']['opt'] as $copt) {
                 if (is_array($copt)) {
-                    $out .= ' ['.$this->getOutTextString($copt[0], $oid, true)
-                        .' '.$this->getOutTextString($copt[1], $oid, true).']';
+                    $out .= ' [' . $this->getOutTextString($copt[0], $oid, true)
+                        . ' ' . $this->getOutTextString($copt[1], $oid, true) . ']';
                 } else {
-                    $out .= ' '.$this->getOutTextString($copt, $oid, true);
+                    $out .= ' ' . $this->getOutTextString($copt, $oid, true);
                 }
             }
             $out .= ']';
         }
         if (isset($annot['opt']['ti'])) {
-            $out .= ' /TI '.intval($annot['opt']['ti']);
+            $out .= ' /TI ' . intval($annot['opt']['ti']);
         }
         if (!empty($annot['opt']['i']) && is_array($annot['opt']['i'])) {
             $out .= ' /I [';
             foreach ($annot['opt']['i'] as $copt) {
-                $out .= intval($copt).' ';
+                $out .= intval($copt) . ' ';
             }
             $out .= ']';
         }
@@ -1914,7 +1929,7 @@ abstract class Output extends \Com\Tecnick\Pdf\Text
             $pattern = "ftcpdfdocsaved=this.addField('%s','%s',%d,[%F,%F,%F,%F]);";
             $jsa = sprintf($pattern, 'tcpdfdocsaved', 'text', 0, 0, 1, 0, 1);
             $jsb = "getField('tcpdfdocsaved').value='saved';";
-            $this->javascript = $jsa."\n".$this->javascript."\n".$jsb;
+            $this->javascript = $jsa . "\n" . $this->javascript . "\n" . $jsb;
         }
         $out = '';
         // name tree for javascript
@@ -1922,25 +1937,25 @@ abstract class Output extends \Com\Tecnick\Pdf\Text
         if (!empty($this->javascript)) {
             // default Javascript object
             $oid = ++$this->pon;
-            $out .= $oid.' 0 obj'."\n"
-            .'<<'
-            .' /S /JavaScript /JS '
-            .$this->getOutTextString($this->javascript, $oid, true)
-            .' >>'."\n"
-            .'endobj'."\n";
-            $njs .= ' (EmbeddedJS) '.$oid.' 0 R';
+            $out .= $oid . ' 0 obj' . "\n"
+            . '<<'
+            . ' /S /JavaScript /JS '
+            . $this->getOutTextString($this->javascript, $oid, true)
+            . ' >>' . "\n"
+            . 'endobj' . "\n";
+            $njs .= ' (EmbeddedJS) ' . $oid . ' 0 R';
         }
         foreach ($this->jsobjects as $key => $val) {
             if ($val['onload']) {
                 // additional Javascript object
                 $oid = ++$this->pon;
-                $out .= $oid.' 0 obj'."\n"
-                .'<< '
-                .'/S /JavaScript /JS '
-                .$this->getOutTextString($val['js'], $oid, true)
-                .' >>'."\n"
-                .'endobj'."\n";
-                $njs .= ' (JS'.$key.') '.$oid.' 0 R';
+                $out .= $oid . ' 0 obj' . "\n"
+                . '<< '
+                . '/S /JavaScript /JS '
+                . $this->getOutTextString($val['js'], $oid, true)
+                . ' >>' . "\n"
+                . 'endobj' . "\n";
+                $njs .= ' (JS' . $key . ') ' . $oid . ' 0 R';
             }
         }
         $njs .= ' ] >>';
@@ -1962,7 +1977,7 @@ abstract class Output extends \Com\Tecnick\Pdf\Text
         // sort outlines by page and original position
         array_multisort($outline_p, SORT_NUMERIC, SORT_ASC, $outline_k, SORT_NUMERIC, SORT_ASC, $this->outlines);
     }
-    
+
     /**
      * Process the bookmarks to get the previous and next one.
      *
@@ -2020,7 +2035,7 @@ abstract class Output extends \Com\Tecnick\Pdf\Text
         if (empty($this->outlines)) {
             return '';
         }
-        $numbookmarks = is_countable($this->outlines)?count($this->outlines):0;
+        $numbookmarks = is_countable($this->outlines) ? count($this->outlines) : 0;
         if ($numbookmarks <= 0) {
             return;
         }
@@ -2035,21 +2050,21 @@ abstract class Output extends \Com\Tecnick\Pdf\Text
             $title = strip_tags($title);
             $title = preg_replace("/^\s+|\s+$/u", '', $title);
             $oid = ++$this->pon;
-            $out .= $oid.' 0 obj'."\n"
-                .'<<'
-                .' /Title '.$this->getOutTextString($title, $oid, true)
-                .' /Parent '.($first_oid + $o['parent']).' 0 R';
+            $out .= $oid . ' 0 obj' . "\n"
+                . '<<'
+                . ' /Title ' . $this->getOutTextString($title, $oid, true)
+                . ' /Parent ' . ($first_oid + $o['parent']) . ' 0 R';
             if (isset($o['prev'])) {
-                $out .= ' /Prev '.($first_oid + $o['prev']).' 0 R';
+                $out .= ' /Prev ' . ($first_oid + $o['prev']) . ' 0 R';
             }
             if (isset($o['next'])) {
-                $out .= ' /Next '.($first_oid + $o['next']).' 0 R';
+                $out .= ' /Next ' . ($first_oid + $o['next']) . ' 0 R';
             }
             if (isset($o['first'])) {
-                $out .= ' /First '.($first_oid + $o['first']).' 0 R';
+                $out .= ' /First ' . ($first_oid + $o['first']) . ' 0 R';
             }
             if (isset($o['last'])) {
-                $out .= ' /Last '.($first_oid + $o['last']).' 0 R';
+                $out .= ' /Last ' . ($first_oid + $o['last']) . ' 0 R';
             }
             if (!empty($o['u'])) {
                 // link
@@ -2057,31 +2072,32 @@ abstract class Output extends \Com\Tecnick\Pdf\Text
                     switch ($o['u'][0]) {
                         case '#':
                             // internal destination
-                            $out .= ' /Dest /'.$this->encrypt->encodeNameObject(substr($o['u'], 1));
+                            $out .= ' /Dest /' . $this->encrypt->encodeNameObject(substr($o['u'], 1));
                             break;
                         case '%':
                             // embedded PDF file
                             $filename = basename(substr($o['u'], 1));
                             $out .= ' /A <<'
-                                .' /S /GoToE /D [0 /Fit] /NewWindow true /T'
-                                .' << /R /C /P '.($o['p'] - 1).' /A '.$this->embeddedfiles[$filename]['a'].' >>'
-                                .' >>';
+                                . ' /S /GoToE /D [0 /Fit] /NewWindow true /T'
+                                . ' << /R /C /P ' . ($o['p'] - 1) . ' /A '
+                                . $this->embeddedfiles[$filename]['a'] . ' >>'
+                                . ' >>';
                             break;
                         case '*':
                             // embedded generic file
                             $filename = basename(substr($o['u'], 1));
                             $jsa = 'var D=event.target.doc;'
-                            .'var MyData=D.dataObjects;'
-                            .'for (var i in MyData)'
-                            .' if (MyData[i].path=="'.$filename.'")'
-                            .' D.exportDataObject( { cName : MyData[i].name, nLaunch : 2});';
-                            $out .= ' /A <</S /JavaScript /JS '.$this->getOutTextString($jsa, $oid, true).'>>';
+                            . 'var MyData=D.dataObjects;'
+                            . 'for (var i in MyData)'
+                            . ' if (MyData[i].path=="' . $filename . '")'
+                            . ' D.exportDataObject( { cName : MyData[i].name, nLaunch : 2});';
+                            $out .= ' /A <</S /JavaScript /JS ' . $this->getOutTextString($jsa, $oid, true) . '>>';
                             break;
                         default:
                             // external URI link
                             $out .= ' /A << /S /URI /URI '
-                                .$this->encrypt->escapeDataString($this->unhtmlentities($o['u']), $oid)
-                                .' >>';
+                                . $this->encrypt->escapeDataString($this->unhtmlentities($o['u']), $oid)
+                                . ' >>';
                             break;
                     }
                 } elseif (isset($this->links[$o['u']])) {
@@ -2096,7 +2112,7 @@ abstract class Output extends \Com\Tecnick\Pdf\Text
                 $page = $this->page->getPage($o['p']);
                 $x = ($o['x'] * $this->k);
                 $y = ($page['height'] - ($o['y'] * $this->k));
-                $out .= ' '.sprintf('/Dest [%u 0 R /XYZ %F %F null]', $page['n'], $x, $y);
+                $out .= ' ' . sprintf('/Dest [%u 0 R /XYZ %F %F null]', $page['n'], $x, $y);
             }
             // set font style
             $style = 0;
@@ -2111,23 +2127,23 @@ abstract class Output extends \Com\Tecnick\Pdf\Text
             $out .= sprintf(' /F %d', $style);
             // set bookmark color
             if (!empty($o['c']) && is_array($o['c'])) {
-                $out .= ' /C ['.$this->getColorStringFromArray($o['c']).']';
+                $out .= ' /C [' . $this->getColorStringFromArray($o['c']) . ']';
             } else {
                 $out .= ' /C [0.0 0.0 0.0]'; // black
             }
             $out .= ' /Count 0' // normally closed item
-                .' >>'."\n"
-                .'endobj';
+                . ' >>' . "\n"
+                . 'endobj';
         }
         //Outline root
         $this->OutlineRoot = ++$this->pon;
-        $out .= $this->OutlineRoot.' 0 obj'."\n"
-            .'<<'
-            .' /Type /Outlines'
-            .' /First '.$first_oid.' 0 R'
-            .' /Last '.($first_oid + $root_oid).' 0 R'
-            .' >>'."\n"
-            .'endobj';
+        $out .= $this->OutlineRoot . ' 0 obj' . "\n"
+            . '<<'
+            . ' /Type /Outlines'
+            . ' /First ' . $first_oid . ' 0 R'
+            . ' /Last ' . ($first_oid + $root_oid) . ' 0 R'
+            . ' >>' . "\n"
+            . 'endobj';
         return $out;
     }
 
@@ -2143,19 +2159,19 @@ abstract class Output extends \Com\Tecnick\Pdf\Text
         }
         foreach ($this->signature['appearance']['empty'] as $key => $esa) {
             $page = $this->page->getPage($esa['page']);
-            $signame = $esa['name'].sprintf(' [%03d]', ($key + 1));
-            $out .= $esa['objid'].' 0 obj'."\n"
-                .'<<'
-                .' /Type /Annot'
-                .' /Subtype /Widget'
-                .' /Rect ['.$esa['rect'].']'
-                .' /P '.$page['n'].' 0 R' // link to signature appearance page
-                .' /F 4'
-                .' /FT /Sig'
-                .' /T '.$this->getOutTextString($signame, $esa['objid'], true)
-                .' /Ff 0'
-                .' >>'
-                ."\n".'endobj';
+            $signame = $esa['name'] . sprintf(' [%03d]', ($key + 1));
+            $out .= $esa['objid'] . ' 0 obj' . "\n"
+                . '<<'
+                . ' /Type /Annot'
+                . ' /Subtype /Widget'
+                . ' /Rect [' . $esa['rect'] . ']'
+                . ' /P ' . $page['n'] . ' 0 R' // link to signature appearance page
+                . ' /F 4'
+                . ' /FT /Sig'
+                . ' /T ' . $this->getOutTextString($signame, $esa['objid'], true)
+                . ' /Ff 0'
+                . ' >>'
+                . "\n" . 'endobj';
         }
         return $out;
     }
@@ -2183,7 +2199,7 @@ abstract class Output extends \Com\Tecnick\Pdf\Text
         $byte_range[1] = strpos($pdfdoc, $this->byterange) + $byterange_strlen + 10;
         $byte_range[2] = $byte_range[1] + $this->sigmaxlen + 2;
         $byte_range[3] = strlen($pdfdoc) - $byte_range[2];
-        $pdfdoc = substr($pdfdoc, 0, $byte_range[1]).substr($pdfdoc, $byte_range[2]);
+        $pdfdoc = substr($pdfdoc, 0, $byte_range[1]) . substr($pdfdoc, $byte_range[2]);
         // replace the ByteRange
         $byterange = sprintf('/ByteRange[0 %u %u %u]', $byte_range[1], $byte_range[2], $byte_range[3]);
         $byterange .= str_repeat(' ', ($byterange_strlen - strlen($byterange)));
@@ -2233,7 +2249,7 @@ abstract class Output extends \Com\Tecnick\Pdf\Text
         $signature = current(unpack('H*', $signature));
         $signature = str_pad($signature, $this->sigmaxlen, '0');
         // Add signature to the document
-        $out = substr($pdfdoc, 0, $byte_range[1]).'<'.$signature.'>'.substr($pdfdoc, $byte_range[1]);
+        $out = substr($pdfdoc, 0, $byte_range[1]) . '<' . $signature . '>' . substr($pdfdoc, $byte_range[1]);
         return $out;
     }
 
@@ -2264,29 +2280,29 @@ abstract class Output extends \Com\Tecnick\Pdf\Text
         $soid = $this->objid['signature'];
         $oid = $soid + 1;
         $page = $this->page->getPage($this->signature['appearance']['page']);
-        $out = $soid.' 0 obj'."\n"
-            .'<<'
-            .' /Type /Annot'
-            .' /Subtype /Widget'
-            .' /Rect ['.$this->signature['appearance']['rect'].']'
-            .' /P '.$page['n'].' 0 R' // link to signature appearance page
-            .' /F 4'
-            .' /FT /Sig'
-            .' /T '.$this->getOutTextString($this->signature['appearance']['name'], $soid, true)
-            .' /Ff 0'
-            .' /V '.$oid.' 0 R'
-            .' >>'."\n"
-            .'endobj';
-        $out .= $oid.' 0 obj'."\n";
+        $out = $soid . ' 0 obj' . "\n"
+            . '<<'
+            . ' /Type /Annot'
+            . ' /Subtype /Widget'
+            . ' /Rect [' . $this->signature['appearance']['rect'] . ']'
+            . ' /P ' . $page['n'] . ' 0 R' // link to signature appearance page
+            . ' /F 4'
+            . ' /FT /Sig'
+            . ' /T ' . $this->getOutTextString($this->signature['appearance']['name'], $soid, true)
+            . ' /Ff 0'
+            . ' /V ' . $oid . ' 0 R'
+            . ' >>' . "\n"
+            . 'endobj';
+        $out .= $oid . ' 0 obj' . "\n";
         $out .= '<<'
-            .' /Type /Sig'
-            .' /Filter /Adobe.PPKLite'
-            .' /SubFilter /adbe.pkcs7.detached '
-            .$this->byterange
-            .' /Contents<'.str_repeat('0', $this->sigmaxlen).'>';
+            . ' /Type /Sig'
+            . ' /Filter /Adobe.PPKLite'
+            . ' /SubFilter /adbe.pkcs7.detached '
+            . $this->byterange
+            . ' /Contents<' . str_repeat('0', $this->sigmaxlen) . '>';
         if (empty($this->signature['approval']) || ($this->signature['approval'] != 'A')) {
             $out .= ' /Reference [' // array of signature reference dictionaries
-                .' << /Type /SigRef';
+                . ' << /Type /SigRef';
             if ($this->signature['cert_type'] > 0) {
                 $out .= $this->getOutSignatureDocMDP();
             } else {
@@ -2298,13 +2314,13 @@ abstract class Output extends \Com\Tecnick\Pdf\Text
             //    .' /DigestLocation[********** 34]'
             //    .' /DigestValue<********************************>';
             $out .= ' >>'
-                .' ]'; // end of reference
+                . ' ]'; // end of reference
         }
         $out .= $this->getOutSignatureInfo();
         $out .= ' /M '
-            .$this->getOutDateTimeString($this->docmodtime, $oid)
-            .' >>'."\n"
-            .'endobj';
+            . $this->getOutDateTimeString($this->docmodtime, $oid)
+            . ' >>' . "\n"
+            . 'endobj';
         return $out;
     }
 
@@ -2316,12 +2332,12 @@ abstract class Output extends \Com\Tecnick\Pdf\Text
     protected function getOutSignatureDocMDP()
     {
         $out .= ' /TransformMethod /DocMDP'
-            .' /TransformParams'
-            .' <<'
-            .' /Type /TransformParams'
-            .' /P '.$this->signature['cert_type']
-            .' /V /1.2'
-            .' >>';
+            . ' /TransformParams'
+            . ' <<'
+            . ' /Type /TransformParams'
+            . ' /P ' . $this->signature['cert_type']
+            . ' /V /1.2'
+            . ' >>';
         return $out;
     }
 
@@ -2333,27 +2349,27 @@ abstract class Output extends \Com\Tecnick\Pdf\Text
     protected function getOutSignatureUserRights()
     {
         $out = ' /TransformMethod /UR3'
-            .' /TransformParams'
-            .' <<'
-            .' /Type /TransformParams'
-            .' /V /2.2';
+            . ' /TransformParams'
+            . ' <<'
+            . ' /Type /TransformParams'
+            . ' /V /2.2';
         if (!empty($this->userrights['document'])) {
-            $out .= ' /Document['.$this->userrights['document'].']';
+            $out .= ' /Document[' . $this->userrights['document'] . ']';
         }
         if (!empty($this->userrights['form'])) {
-            $out .= ' /Form['.$this->userrights['form'].']';
+            $out .= ' /Form[' . $this->userrights['form'] . ']';
         }
         if (!empty($this->userrights['signature'])) {
-            $out .= ' /Signature['.$this->userrights['signature'].']';
+            $out .= ' /Signature[' . $this->userrights['signature'] . ']';
         }
         if (!empty($this->userrights['annots'])) {
-            $out .= ' /Annots['.$this->userrights['annots'].']';
+            $out .= ' /Annots[' . $this->userrights['annots'] . ']';
         }
         if (!empty($this->userrights['ef'])) {
-            $out .= ' /EF['.$this->userrights['ef'].']';
+            $out .= ' /EF[' . $this->userrights['ef'] . ']';
         }
         if (!empty($this->userrights['formex'])) {
-            $out .= ' /FormEX['.$this->userrights['formex'].']';
+            $out .= ' /FormEX[' . $this->userrights['formex'] . ']';
         }
         $out .= ' >>';
         return $out;
@@ -2368,16 +2384,16 @@ abstract class Output extends \Com\Tecnick\Pdf\Text
     {
         $out = '';
         if (!empty($this->signature['info']['Name'])) {
-            $out .= ' /Name '.$this->getOutTextString($this->signature['info']['Name'], $oid, true);
+            $out .= ' /Name ' . $this->getOutTextString($this->signature['info']['Name'], $oid, true);
         }
         if (!empty($this->signature['info']['Location'])) {
-            $out .= ' /Location '.$this->getOutTextString($this->signature['info']['Location'], $oid, true);
+            $out .= ' /Location ' . $this->getOutTextString($this->signature['info']['Location'], $oid, true);
         }
         if (!empty($this->signature['info']['Reason'])) {
-            $out .= ' /Reason '.$this->getOutTextString($this->signature['info']['Reason'], $oid, true);
+            $out .= ' /Reason ' . $this->getOutTextString($this->signature['info']['Reason'], $oid, true);
         }
         if (!empty($this->signature['info']['ContactInfo'])) {
-            $out .= ' /ContactInfo '.$this->getOutTextString($this->signature['info']['ContactInfo'], $oid, true);
+            $out .= ' /ContactInfo ' . $this->getOutTextString($this->signature['info']['ContactInfo'], $oid, true);
         }
         return $out;
     }
@@ -2395,7 +2411,7 @@ abstract class Output extends \Com\Tecnick\Pdf\Text
         }
         $out = ' /Font <<';
         foreach ($fonts as $font) {
-            $out .= ' /F'.$font['i'].' '.$font['n'].' 0 R';
+            $out .= ' /F' . $font['i'] . ' ' . $font['n'] . ' 0 R';
         }
         $out .= ' >>';
         return $out;
@@ -2410,7 +2426,7 @@ abstract class Output extends \Com\Tecnick\Pdf\Text
     {
         $out = ' /XObject <<';
         foreach ($this->xobject as $id => $oid) {
-            $out .= ' /'.$id.' '.$oid['n'].' 0 R';
+            $out .= ' /' . $id . ' ' . $oid['n'] . ' 0 R';
         }
         $out .= $this->image->getXobjectDict();
         $out .= ' >>';
@@ -2429,7 +2445,7 @@ abstract class Output extends \Com\Tecnick\Pdf\Text
         }
         $out = ' /Properties <<';
         foreach ($this->pdflayer as $layer) {
-            $out .= ' /'.$layer['layer'].' '.$layer['objid'].' 0 R';
+            $out .= ' /' . $layer['layer'] . ' ' . $layer['objid'] . ' 0 R';
         }
         $out .= ' >>';
         return $out;
@@ -2472,12 +2488,12 @@ abstract class Output extends \Com\Tecnick\Pdf\Text
         header('Cache-Control: private, must-revalidate, post-check=0, pre-check=0, max-age=1');
         header('Pragma: public');
         header('Expires: Sat, 01 Jan 2000 01:00:00 GMT'); // Date in the past
-        header('Last-Modified: '.gmdate('D, d M Y H:i:s').' GMT');
-        header('Content-Disposition: inline; filename="'.$this->encpdffilename.'"; filename*=UTF-8\'\''
-        .$this->encpdffilename);
+        header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
+        header('Content-Disposition: inline; filename="' . $this->encpdffilename . '"; filename*=UTF-8\'\''
+        . $this->encpdffilename);
         if (empty($_SERVER['HTTP_ACCEPT_ENCODING'])) {
             // the content length may vary if the server is using compression
-            header('Content-Length: '.strlen($rawpdf));
+            header('Content-Length: ' . strlen($rawpdf));
         }
         echo $rawpdf;
     }
@@ -2505,7 +2521,7 @@ abstract class Output extends \Com\Tecnick\Pdf\Text
         header('Cache-Control: private, must-revalidate, post-check=0, pre-check=0, max-age=1');
         header('Pragma: public');
         header('Expires: Sat, 01 Jan 2000 01:00:00 GMT'); // Date in the past
-        header('Last-Modified: '.gmdate('D, d M Y H:i:s').' GMT');
+        header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
         // force download dialog
         header('Content-Type: application/pdf');
         if (strpos(php_sapi_name(), 'cgi') === false) {
@@ -2514,12 +2530,12 @@ abstract class Output extends \Com\Tecnick\Pdf\Text
             header('Content-Type: application/download', false);
         }
         // use the Content-Disposition header to supply a recommended filename
-        header('Content-Disposition: attachment; filename="'.$this->encpdffilename.'";'
-        .' filename*=UTF-8\'\''.$this->encpdffilename);
+        header('Content-Disposition: attachment; filename="' . $this->encpdffilename . '";'
+        . ' filename*=UTF-8\'\'' . $this->encpdffilename);
         header('Content-Transfer-Encoding: binary');
         if (empty($_SERVER['HTTP_ACCEPT_ENCODING'])) {
             // the content length may vary if the server is using compression
-            header('Content-Length: '.strlen($rawpdf));
+            header('Content-Length: ' . strlen($rawpdf));
         }
         echo $rawpdf;
     }
@@ -2534,7 +2550,7 @@ abstract class Output extends \Com\Tecnick\Pdf\Text
         $filepath = join('/', array(realpath($path), $this->pdffilename));
         $fhd = $this->file->fopenLocal($filepath, 'wb');
         if (!$fhd) {
-            throw new PdfException('Unable to create output file: '.$filepath);
+            throw new PdfException('Unable to create output file: ' . $filepath);
         }
         fwrite($fhd, $rawpdf, strlen($rawpdf));
         fclose($fhd);
@@ -2549,11 +2565,11 @@ abstract class Output extends \Com\Tecnick\Pdf\Text
      */
     public function getMIMEAttachmentPDF($rawpdf = '')
     {
-        return 'Content-Type: application/pdf;'."\r\n"
-        .' name="'.$this->encpdffilename.'"'."\r\n"
-        .'Content-Transfer-Encoding: base64'."\r\n"
-        .'Content-Disposition: attachment;'."\r\n"
-        .' filename="'.$this->encpdffilename.'"'."\r\n\r\n"
-        .chunk_split(base64_encode($rawpdf), 76, "\r\n");
+        return 'Content-Type: application/pdf;' . "\r\n"
+        . ' name="' . $this->encpdffilename . '"' . "\r\n"
+        . 'Content-Transfer-Encoding: base64' . "\r\n"
+        . 'Content-Disposition: attachment;' . "\r\n"
+        . ' filename="' . $this->encpdffilename . '"' . "\r\n\r\n"
+        . chunk_split(base64_encode($rawpdf), 76, "\r\n");
     }
 }

--- a/src/Tcpdf.php
+++ b/src/Tcpdf.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Tcpdf.php
  *
@@ -15,8 +16,8 @@
 
 namespace Com\Tecnick\Pdf;
 
-use \Com\Tecnick\Pdf\Exception as PdfException;
-use \Com\Tecnick\Pdf\Encrypt\Encrypt as ObjEncrypt;
+use Com\Tecnick\Pdf\Exception as PdfException;
+use Com\Tecnick\Pdf\Encrypt\Encrypt as ObjEncrypt;
 
 /**
  * Com\Tecnick\Pdf\Tcpdf
@@ -168,7 +169,7 @@ class Tcpdf extends \Com\Tecnick\Pdf\ClassObjects
         $this->docmodtime = $this->doctime;
         $seedobj = new \Com\Tecnick\Pdf\Encrypt\Type\Seed();
         $this->fileid = md5($seedobj->encrypt('TCPDF'));
-        $this->setPDFFilename($this->fileid.'.pdf');
+        $this->setPDFFilename($this->fileid . '.pdf');
         $this->unit = $unit;
         $this->setUnicodeMode($isunicode);
         $this->subsetfont = (bool) $subsetfont;

--- a/src/Text.php
+++ b/src/Text.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Text.php
  *
@@ -15,7 +16,7 @@
 
 namespace Com\Tecnick\Pdf;
 
-use \Com\Tecnick\Unicode\Bidi;
+use Com\Tecnick\Unicode\Bidi;
 
 /**
  * Com\Tecnick\Pdf\Text
@@ -34,17 +35,16 @@ use \Com\Tecnick\Unicode\Bidi;
  */
 abstract class Text
 {
-    
     /**
      * Last text bounding box [llx, lly, urx, ury].
      *
      * @var array
      */
     protected $lasttxtbbox = array(
-        'llx'=>0,
-        'lly'=>0,
-        'urx'=>0,
-        'ury'=>0
+        'llx' => 0,
+        'lly' => 0,
+        'urx' => 0,
+        'ury' => 0
     );
 
     /**
@@ -79,7 +79,7 @@ abstract class Text
         $clip = false,
         $forcertl = false
     ) {
-        $width = $width>0?$width:0;
+        $width = $width > 0 ? $width : 0;
         $curfont = $this->font->getCurrentFont();
         $this->lasttxtbbox = array(
             'llx' => $xpos,
@@ -131,7 +131,7 @@ abstract class Text
         // converts an UTF-8 string to an array of UTF-8 codepoints (integer values)
         $ordarr = $this->uniconv->strToOrdArr($txt);
         $dim = $this->font->getOrdArrDims($ordarr);
-        $spacewidth = (($width - $dim['totwidth'] + $dim['totspacewidth']) / ($dim['spaces']?$dim['spaces']:1));
+        $spacewidth = (($width - $dim['totwidth'] + $dim['totspacewidth']) / ($dim['spaces'] ? $dim['spaces'] : 1));
         if (!$this->isunicode) {
             $txt = $this->encrypt->escapeString($txt);
             $txt = $this->getOutTextShowing($txt, 'Tj');
@@ -153,9 +153,9 @@ abstract class Text
             $this->lasttxtbbox['urx'] += $dim['totwidth'];
             return $this->getOutTextShowing($txt, 'Tj');
         }
-        $fontsize = $this->font->getCurrentFont()['size']?$this->font->getCurrentFont()['size']:1;
+        $fontsize = $this->font->getCurrentFont()['size'] ? $this->font->getCurrentFont()['size'] : 1;
         $spacewidth = -1000 * $spacewidth / $fontsize;
-        $txt = str_replace(chr(0).chr(32), ') '.sprintf('%F', $spacewidth).' (', $txt);
+        $txt = str_replace(chr(0) . chr(32), ') ' . sprintf('%F', $spacewidth) . ' (', $txt);
         return $this->getOutTextShowing($txt, 'TJ');
     }
 
@@ -173,11 +173,11 @@ abstract class Text
     {
         switch ($mode) {
             case 'Td': // Move to the start of the next line, offset from the start of the current line by (xpos, ypos).
-                return sprintf('%F %F Td '.$raw, $xpos, $ypos);
+                return sprintf('%F %F Td ' . $raw, $xpos, $ypos);
             case 'TD': // Same as: -xpos TL xpos ypos Td
-                return sprintf('%F %F TD '.$raw, $xpos, $ypos);
+                return sprintf('%F %F TD ' . $raw, $xpos, $ypos);
             case 'T*': // Move to the start of the next line.
-                return sprintf('T* '.$raw);
+                return sprintf('T* ' . $raw);
         }
         return '';
     }
@@ -207,7 +207,7 @@ abstract class Text
         // 101 = Fill text and add to path for clipping.
         // 110 = Stroke text and add to path for clipping.
         // 111 = Fill, then stroke text and add to path for clipping.
-        return ($mode -1);
+        return ($mode - 1);
     }
 
     /**
@@ -226,34 +226,34 @@ abstract class Text
                 if ($value == 0) {
                     break;
                 }
-                return sprintf('%F Tc '.$raw.' 0 Tc', ($value * $this->kunit));
+                return sprintf('%F Tc ' . $raw . ' 0 Tc', ($value * $this->kunit));
             case 'Tw': // word spacing
                 if ($value == 0) {
                     break;
                 }
-                return sprintf('%F Tw '.$raw.' 0 Tw', ($value * $this->kunit));
+                return sprintf('%F Tw ' . $raw . ' 0 Tw', ($value * $this->kunit));
             case 'Tz': // horizontal scaling
                 if ($value == 1) {
                     break;
                 }
-                return sprintf('%F Tz '.$raw.' 100 Tz', ($value * 100));
+                return sprintf('%F Tz ' . $raw . ' 100 Tz', ($value * 100));
             case 'TL': // text leading
                 if ($value == 0) {
                     break;
                 }
-                return sprintf('%F TL '.$raw.' 0 TL', $value);
+                return sprintf('%F TL ' . $raw . ' 0 TL', $value);
             case 'Tr': // text rendering
                 if (($value < 0) || ($value > 7)) {
                     break;
                 }
-                return sprintf('%d Tr '.$raw, $value);
+                return sprintf('%d Tr ' . $raw, $value);
             case 'Ts': // text rise
                 if ($value == 0) {
                     break;
                 }
-                return sprintf('%F Ts '.$raw.' 0 Ts', $value);
+                return sprintf('%F Ts ' . $raw . ' 0 Ts', $value);
             case 'w': // stroke width
-                return sprintf('%F w '.$raw, ($value > 0 ? ($value * $this->kunit) : 0));
+                return sprintf('%F w ' . $raw, ($value > 0 ? ($value * $this->kunit) : 0));
         }
         return $raw;
     }
@@ -272,7 +272,7 @@ abstract class Text
             return '';
         }
         return sprintf(
-            '%F %F %F %F %F %F Tm '.$raw,
+            '%F %F %F %F %F %F Tm ' . $raw,
             $matrix[0],
             $matrix[1],
             $matrix[2],
@@ -294,11 +294,11 @@ abstract class Text
     {
         switch ($mode) {
             case 'Tj': // Show a text string.
-                return '('.$str.') Tj';
+                return '(' . $str . ') Tj';
             case 'TJ': // Show one or more text strings, allowing individual glyph positioning.
-                return '[('.$str.')] TJ';
+                return '[(' . $str . ')] TJ';
             case '\'': // Move to the next line and show a text string. Same as: T* $str Tj
-                return '('.$str.') \'';
+                return '(' . $str . ') \'';
         }
         return '';
     }
@@ -312,7 +312,7 @@ abstract class Text
      */
     protected function getOutTextObject($raw = '')
     {
-        return 'BT '.$raw.' BE'."\r";
+        return 'BT ' . $raw . ' BE' . "\r";
     }
 
     /**

--- a/test/TcpdfTest.php
+++ b/test/TcpdfTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * TcpdfTest.php
  *

--- a/test/TestUtil.php
+++ b/test/TestUtil.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * TestUtil.php
  *


### PR DESCRIPTION
# Description
PSR-2 has been deprecated about 4 years ago and PSR-12 is what is considered industry standard now. The code in this repository is almost PSR-12 compliant, so I took the liberty to convert it all the way and change the standard in the Makefile to PSR-12. In order to help IDEs, I also added an .editorconfig file, to configure some of the codestyle automatically.

...


## Checklist:

- [ ] The `make buildall` command has been run successfully without any error or warning.
- [ ] Any new code line is covered by unit tests and the coverage has not dropped.
- [ ] Any new code follows the style guidelines of this project.
- [ ] The code changes have been self-reviewed.
- [ ] Corresponding changes to the documentation have been made.
- [ ] The version has been updated in the VERSION file.

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue) → The patch number in the VERSION file has been increased.
- [ ] New feature (non-breaking change which adds functionality) → The minor number in the VERSION file has been increased.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) → The major number in the VERSION file has been increased.
- [X] Automation.
- [ ] Documentation.
- [ ] Example.
- [X] Testing.
