### PR TITLE
Random fixes

### DIFF
--- a/src/HTML.php
+++ b/src/HTML.php
@@ -536,7 +536,7 @@ abstract class HTML extends \Com\Tecnick\Pdf\JavaScript
             $html,
         ) ?? '';
         $html = \preg_replace(
-            '/<\/(table|tr|td|th|blockquote|dd|dt|dl|div|dt|h1|h2|h3|h4|h5|h6|hr|li|ol|ul|p)>[\s]+</',
+            '/<\/(table|tr|td|th|blockquote|dd|dt|dl|div|h1|h2|h3|h4|h5|h6|hr|li|ol|ul|p)>[\s]+</',
             '</\\1><',
             $html,
         ) ?? '';


### PR DESCRIPTION
HTML class compares a single character in a match statement against a two character string 'o '.

Separately, there is a duplicated 'dt' in a regex statement.