### PR TITLE
fix: correct PDF/UA structure tagging for HTML tables and rules

### DIFF
--- a/src/HTML.php
+++ b/src/HTML.php
@@ -7205,8 +7205,20 @@ abstract class HTML extends \Com\Tecnick\Pdf\JavaScript
             return '';
         }
 
+        // The header repeated at the top of a continuation page is a visual
+        // running header, not new document structure. Render it (and its
+        // measurement pass) with PDF/UA tagging suspended so it does not push
+        // its own Table/TR/TH structure elements: those would remain open on
+        // the structure stack and detach the table's continuation rows from the
+        // Table element. The repeated header is then emitted as a single
+        // Artifact, while the original header stays the tagged one.
+        $savedPdfuaMode = $this->pdfuaMode;
+        $this->pdfuaMode = '';
         $theadh = $this->measureHTMLCellRenderedHeight($thead, $tpx, $tpy, $tpw, $tph);
         $out = $this->getHTMLCell($thead, $tpx, $tpy, $tpw, $tph);
+        $this->pdfuaMode = $savedPdfuaMode;
+        $out = $this->tagPdfUaArtifactContent($out);
+
         if ($theadh > 0.0) {
             $tpy += $theadh;
             $this->resetHTMLLineCursor($hrc, $tpx, $tpw);
@@ -17993,14 +18005,14 @@ abstract class HTML extends \Com\Tecnick\Pdf\JavaScript
         }
 
         $lineY = $tpy + ($this->getHTMLLineAdvance($hrc, $key) / 2);
-        $out .= $this->graph->getLine($tpx, $lineY, $tpx + $width, $lineY, [
+        $out .= $this->tagPdfUaArtifactContent($this->graph->getLine($tpx, $lineY, $tpx + $width, $lineY, [
             'lineWidth' => $strokeWidth,
             'lineCap' => 'butt',
             'lineJoin' => 'miter',
             'dashArray' => [],
             'dashPhase' => 0,
             'lineColor' => $elm['fgcolor'] === '' ? 'black' : $elm['fgcolor'],
-        ]);
+        ]));
         $this->moveHTMLToNextLine($hrc, $key, $tpx, $tpy, $tpw);
 
         return $out;
@@ -19448,16 +19460,6 @@ abstract class HTML extends \Com\Tecnick\Pdf\JavaScript
             return '';
         }
 
-        if ($this->pdfuaMode !== '') {
-            $role = $elm['value'] === 'th' ? 'TH' : 'TD';
-            $attr = [];
-            if ($role === 'TH') {
-                $attr = ['O' => 'Table', 'Scope' => 'Column'];
-            }
-
-            $this->beginStructElem($role, $this->page->getPageId(), null, $attr);
-        }
-
         $table = $tableNode;
 
         $colindex = $this->getHTMLTableNextFreeColumn($table);
@@ -19482,6 +19484,27 @@ abstract class HTML extends \Com\Tecnick\Pdf\JavaScript
         }
         $colspan = \max(1, \min($remaining, $colspan));
         $rowspan = \max(1, $rowspan);
+
+        if ($this->pdfuaMode !== '') {
+            $role = $elm['value'] === 'th' ? 'TH' : 'TD';
+            $attr = [];
+            if ($role === 'TH') {
+                $attr = ['O' => 'Table', 'Scope' => 'Column'];
+            }
+
+            if ($colspan > 1 || $rowspan > 1) {
+                $attr['O'] = 'Table';
+                if ($colspan > 1) {
+                    $attr['ColSpan'] = $colspan;
+                }
+
+                if ($rowspan > 1) {
+                    $attr['RowSpan'] = $rowspan;
+                }
+            }
+
+            $this->beginStructElem($role, $this->page->getPageId(), null, $attr);
+        }
 
         $cellx = $this->getHTMLTableColX($table, $colindex);
         $cellw = $this->getHTMLTableColSpanWidth($table, $colindex, $colspan);

--- a/src/Output.php
+++ b/src/Output.php
@@ -1784,7 +1784,11 @@ abstract class Output extends \Com\Tecnick\Pdf\MetaInfo
                         continue;
                     }
 
-                    $attrPairs .= ' /' . $akey . ' /' . $aval;
+                    // Integer attribute values (e.g. ColSpan/RowSpan) must be
+                    // emitted as PDF numbers; string values are PDF names.
+                    $attrPairs .= \is_int($aval)
+                        ? ' /' . $akey . ' ' . $aval
+                        : ' /' . $akey . ' /' . $aval;
                 }
 
                 if ($attrPairs !== '') {

--- a/src/Text.php
+++ b/src/Text.php
@@ -854,8 +854,17 @@ abstract class Text extends \Com\Tecnick\Pdf\Cell
         $top = $this->pdfuaStructStack[$topIndex];
         unset($this->pdfuaStructStack[$topIndex]);
 
-        // Only log elements that received marked-content or nested structure children.
-        if ($top['kids'] !== [] || isset($top['annots']) && $top['annots'] !== []) {
+        // Log elements that received marked-content or nested structure children.
+        // Table cells (TD/TH) are also kept when empty: an empty cell is still a
+        // column, so dropping it would make a row report fewer columns than its
+        // header and break table structure validation.
+        $topRole = $top['role'] ?? '';
+        if (
+            $top['kids'] !== []
+            || (isset($top['annots']) && $top['annots'] !== [])
+            || $topRole === 'TD'
+            || $topRole === 'TH'
+        ) {
             $entryIndex = \count($this->pdfuaStructLog);
             $this->pdfuaStructLog[] = $top;
 

--- a/test/HTMLTest.php
+++ b/test/HTMLTest.php
@@ -20346,4 +20346,104 @@ class HTMLTest extends TestUtil
 
         $this->assertNotSame('', $obj->getOutPDFString());
     }
+
+    /**
+     * A horizontal rule is presentational: in PDF/UA mode its stroke must be
+     * tagged as an Artifact, not left as untagged real content.
+     *
+     * @throws \Throwable
+     */
+    public function testParseHTMLTagOPENhrIsTaggedAsArtifactInPdfua(): void
+    {
+        $obj = new \Com\Tecnick\Pdf\Tcpdf('mm', true, false, false, 'pdfua1');
+        $this->initFontAndPage($obj);
+
+        $obj->addHTMLCell('<p>before</p><hr/><p>after</p>', 10, 10, 180, 0);
+
+        $out = $obj->getOutPDFString();
+
+        // The rule's stroke (S operator) is emitted inside an Artifact block.
+        $this->assertMatchesRegularExpression('/\/Artifact\s+BMC[\s\S]*?\sS\s[\s\S]*?EMC/', $out);
+    }
+
+    /**
+     * A cell's colspan must be recorded on its structure element as an integer
+     * layout attribute owned by the table (/O /Table), so a row reports the
+     * correct effective column count for table-structure validation.
+     *
+     * @throws \Throwable
+     */
+    public function testParseHTMLTagOPENtdEmitsIntegerColSpanInPdfua(): void
+    {
+        $obj = new \Com\Tecnick\Pdf\Tcpdf('mm', true, false, false, 'pdfua1');
+        $this->initFontAndPage($obj);
+
+        $html =
+            '<table><tbody>'
+            . '<tr><td>a</td><td>b</td></tr>'
+            . '<tr><td colspan="2">merged</td></tr>'
+            . '</tbody></table>';
+        $obj->addHTMLCell($html, 10, 10, 180, 0);
+
+        $out = $obj->getOutPDFString();
+
+        // Emitted as a PDF integer (/ColSpan 2), not a PDF name (/ColSpan /2).
+        $this->assertStringContainsString('/ColSpan 2', $out);
+        $this->assertStringNotContainsString('/ColSpan /2', $out);
+        $this->assertStringContainsString('/O /Table', $out);
+    }
+
+    /**
+     * An empty table cell must keep a structure element so its row reports the
+     * same number of columns as the rest of the table (ISO 14289-1 7.2).
+     *
+     * @throws \Throwable
+     */
+    public function testEmptyTableCellsRemainInStructTreeInPdfua(): void
+    {
+        $obj = new \Com\Tecnick\Pdf\Tcpdf('mm', true, false, false, 'pdfua1');
+        $this->initFontAndPage($obj);
+
+        // The second cell is empty; both cells must still produce a TD element.
+        $obj->addHTMLCell('<table><tbody><tr><td>x</td><td></td></tr></tbody></table>', 10, 10, 180, 0);
+
+        $out = $obj->getOutPDFString();
+
+        $this->assertSame(2, \substr_count($out, '/Type /StructElem /S /TD'));
+    }
+
+    /**
+     * When a table spans a page break its repeated header must not detach the
+     * continuation rows: every row (including those after the break) must stay a
+     * child of the Table, never a direct child of the Document (PDF/UA 7.2).
+     *
+     * @throws \Throwable
+     */
+    public function testTableRowsStayUnderTableAcrossPageBreakInPdfua(): void
+    {
+        $obj = new \Com\Tecnick\Pdf\Tcpdf('mm', true, false, false, 'pdfua1');
+        $this->initFontAndPage($obj);
+
+        $rows = '';
+        for ($i = 1; $i <= 60; ++$i) {
+            $rows .= '<tr><td>Row ' . $i . '</td><td>' . $i . '</td></tr>';
+        }
+
+        // 60 rows force the table body to overflow onto a second page.
+        $html = '<table><thead><tr><th>A</th><th>B</th></tr></thead><tbody>' . $rows . '</tbody></table>';
+        $obj->addHTMLCell($html, 10, 10, 180, 0);
+
+        $out = $obj->getOutPDFString();
+
+        $this->assertSame(
+            1,
+            \preg_match('/(\d+) 0 obj\s*<<\s*\/Type \/StructElem \/S \/Document\b/', $out, $doc),
+        );
+
+        $matched = \preg_match_all('/\/Type \/StructElem \/S \/TR \/P (\d+) 0 R/', $out, $trParents);
+        $this->assertGreaterThan(40, $matched);
+        foreach ($trParents[1] as $parentId) {
+            $this->assertNotSame($doc[1], $parentId, 'A continuation TR is orphaned under the Document.');
+        }
+    }
 }


### PR DESCRIPTION
# Description

Several PDF/UA (ISO 14289-1) tagging defects produced non-compliant output for common HTML constructs. This addresses four of them:

- ```<hr>```: the rule was drawn as an untagged stroke (7.1). It carries no semantics, so it is now emitted as an Artifact.
- Empty table cells: endStructElem() dropped a TD/TH that had no content, so a row reported fewer columns than its header (7.2). Empty cells are now kept in the structure tree.
- colspan/rowspan: cell spans were never recorded on the cell structure element, and the struct-tree serialiser emitted every /A value as a PDF name (/ColSpan /2). Spans are now stored as Table-owned integer attributes (/ColSpan 2).
- Page-spanning tables: the header replayed at the top of a continuation page (replayHTMLTableHead) re-rendered through getHTMLCell, opening nested Table structure elements that were never closed; continuation rows then attached to the Document instead of the Table (7.2). The repeated header is now emitted as an Artifact with tagging suspended, preserving the table's structure context.

Adds regression tests in test/HTMLTest.php. Verified with veraPDF (PDF/UA-1) on documents combining all four constructs.

## Checklist:

- [ ] The `make buildall` command has been run successfully without any error or warning.
- [ ] Any new code line is covered by unit tests and the coverage has not dropped.
- [ ] Any new code follows the style guidelines of this project.
- [ ] The code changes have been self-reviewed.
- [ ] Corresponding changes to the documentation have been made.
- [ ] The version has been updated in the VERSION file.

## Type of change:

- [ ] Minor non-breaking change (e.g., bug fix, dependencies updates) → The patch number in the VERSION file has been increased.
- [ ] New feature (non-breaking change which adds functionality) → The minor number in the VERSION file has been increased.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) → The major number in the VERSION file has been increased.
- [ ] Automation.
- [ ] Documentation.
- [ ] Example.
- [ ] Testing.
